### PR TITLE
Fix Add Bills button and edit balance modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ import SettingsPage           from './components/Settings/SettingsPage'; // Impo
 import ErrorBoundary from './components/ErrorBoundary'; // Import ErrorBoundary
 // ADDED: Import MultiBillModal component
 import MultiBillModal from './components/FinancialSummary/CombinedBillsOverview/MultiBillModal';
+import BankBalanceEditModal from './components/FinancialSummary/FinancialOverviewCards/BankBalanceEditModal';
 
 const { Content } = Layout;
 const { Title }   = Typography;
@@ -66,6 +67,7 @@ function MyApp() {
   const updateBill = financeContext ? financeContext.updateBill : () => console.error("FinanceContext not available for updateBill");
   // Get the toggle function from context
   const toggleBankBalanceEdit = financeContext ? financeContext.toggleBankBalanceEdit : () => console.error("FinanceContext not available for toggleBankBalanceEdit");
+  const isEditingBankBalance = financeContext ? financeContext.isEditingBankBalance : false;
 
   // --- Modal Handlers ---
 
@@ -252,7 +254,7 @@ function MyApp() {
               selectedKey={selectedMenuKey}
               onSelect={handleSelect}
               width={SIDEBAR_WIDTH}
-              // Pass modal handlers if Sidebar needs to trigger them (optional)
+              onEditBalance={handleOpenEditBalanceModal}
               // onAddBill={handleOpenAddBillModal}
               // onEditBill={handleOpenEditBillModal}
             />
@@ -309,6 +311,12 @@ function MyApp() {
         <MultiBillModal
             open={isMultiBillModalVisible}
             onClose={handleCloseMultiBillModal}
+        />
+
+        {/* Bank Balance Edit Modal - globally rendered */}
+        <BankBalanceEditModal
+            open={isEditingBankBalance}
+            onClose={() => toggleBankBalanceEdit(false)}
         />
       </Layout>
 

--- a/src/components/FinancialSummary/CombinedBillsOverview/BillsListSection.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/BillsListSection.jsx
@@ -17,7 +17,7 @@ const BillsListSection = ({
     categories,
     selectedCategory,
     setSelectedCategory,
-    handleAddSingle, // Function to open multiple bills modal (renamed but kept for compatibility)
+    handleAddBill,
     getCategoryIcon,
     selectedAllButtonStyle,
     defaultAllButtonStyle
@@ -42,7 +42,7 @@ const BillsListSection = ({
                         <Button
                             type="primary"
                             icon={<IconPlus size={16} />}
-                            onClick={handleAddSingle} // Use the passed function
+                            onClick={handleAddBill}
                             style={{ display: 'flex', alignItems: 'center', fontWeight: 500 }}
                             className="hide-on-mobile" // Keep class to hide on mobile
                         >
@@ -100,7 +100,7 @@ const BillsListSection = ({
 
 // Add defaultProps for safety, although App.jsx should always pass them
 BillsListSection.defaultProps = {
-  handleAddSingle: () => console.warn("handleAddSingle handler not provided to BillsListSection"),
+  handleAddBill: () => console.warn("handleAddBill handler not provided to BillsListSection"),
   getCategoryIcon: () => null, // Provide a default fallback for the icon function
 };
 

--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
@@ -171,7 +171,7 @@ const CombinedBillsOverview = ({ style }) => {
 
     // --- Event Handlers (Remain in parent) ---
      const handleAddBill = () => {
-         setIsModalVisible(true);
+         setMultiModalVisible(true);
      };
      const handleEdit = (record) => {
          setEditingBill(record);

--- a/src/components/FinancialSummary/FinancialOverviewCards/BankBalanceCard.jsx
+++ b/src/components/FinancialSummary/FinancialOverviewCards/BankBalanceCard.jsx
@@ -1,6 +1,6 @@
 // src/components/FinancialSummary/FinancialOverviewCards/BankBalanceCard.jsx
 
-import React, { useContext, useState } from 'react';
+import React, { useContext } from 'react';
 import { Card, Col, Space, Statistic, Typography, Tooltip } from 'antd';
 import { IconBuildingBank } from '@tabler/icons-react';
 import { FinanceContext } from '../../../contexts/FinanceContext';
@@ -30,10 +30,7 @@ const formatCurrencySuperscript = (value) => {
 
 const BankBalanceCard = ({ isMobile, styles, isComponentLoading }) => {
   // Consume context, including the new state and toggle function
-  const { bankBalance, loadingBalance } = useContext(FinanceContext);
-
-  // State for the modal
-  const [isModalVisible, setIsModalVisible] = useState(false);
+  const { bankBalance, loadingBalance, isEditingBankBalance, toggleBankBalanceEdit } = useContext(FinanceContext);
 
   // Determine text color based on balance
   const bankBalanceColor =
@@ -43,7 +40,7 @@ const BankBalanceCard = ({ isMobile, styles, isComponentLoading }) => {
 
   // Card click handler to open the modal
   const handleCardClick = () => {
-    setIsModalVisible(true);
+    toggleBankBalanceEdit(true);
   };
 
   return (
@@ -113,8 +110,8 @@ const BankBalanceCard = ({ isMobile, styles, isComponentLoading }) => {
 
       {/* Bank Balance Edit Modal */}
       <BankBalanceEditModal
-        open={isModalVisible}
-        onClose={() => setIsModalVisible(false)}
+        open={isEditingBankBalance}
+        onClose={() => toggleBankBalanceEdit(false)}
       />
     </>
   );


### PR DESCRIPTION
## Summary
- connect sidebar edit balance handler to App
- render `BankBalanceEditModal` globally and use context for visibility
- wire up `Add Bills` button to multi bill modal
- rename BillsListSection prop for clarity

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*