### PR TITLE
Remove default focus outline

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -1161,8 +1161,8 @@ textarea {
 
 /* Improved focus states */
 *:focus-visible {
-  outline: 2px solid var(--primary-600) !important;
-  outline-offset: 2px !important;
+  /* outline: 2px solid var(--primary-600) !important; */
+  /* outline-offset: 2px !important; */
 }
 
 /* ==================================================


### PR DESCRIPTION
## Summary
- comment out `outline` styles from `*:focus-visible` so inputs won't show the blue border

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*