### PR TITLE
Fix mobile padding

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -182,7 +182,7 @@ function MyApp() {
                   transition: 'margin-bottom 0.2s ease-in-out'
               }}>
                 {/* Inner div for consistent top margin */}
-                <div style={{ marginTop: isMobileView ? 5 : 24 }}>
+                <div style={{ marginTop: isMobileView ? 0 : 24 }}>
                   <CombinedBillsOverview
                     style={{ height: '100%' }}
                     // Pass modal handlers down
@@ -241,7 +241,7 @@ function MyApp() {
 
   // --- Main Content Area Styling ---
   const contentStyle = {
-    padding: isMobileView ? 'var(--space-4) var(--space-12)' : 'var(--space-24)', // Responsive padding (top, left, right)
+    padding: isMobileView ? '0 var(--space-12)' : 'var(--space-24)', // Responsive padding (top, left, right)
     margin: 0,
     flexGrow: 1, // Allow content to fill available space
     width: '100%',

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -717,7 +717,7 @@ textarea {
     overflow-x: hidden !important;
     padding-bottom: 0 !important;
     margin-bottom: 0 !important;
-    padding-top: 2px !important;
+    padding-top: 0 !important;
   }
   
   .ant-row {


### PR DESCRIPTION
## Summary
- fix CombinedBillsOverview top margin on mobile
- zero out content padding top on mobile
- remove mobile top padding override in global CSS

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*