### PR TITLE
Add fade transition when bill is marked paid

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -1205,3 +1205,13 @@ a {
   opacity: 0;
   animation: pageFadeIn 0.3s ease-out forwards;
 }
+
+/* Fade out effect for bills table rows */
+@keyframes billRowFadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+.bill-row-fade-out {
+  animation: billRowFadeOut 0.3s ease forwards;
+}

--- a/src/components/FinancialSummary/CombinedBillsOverview/BillsListSection.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/BillsListSection.jsx
@@ -20,7 +20,8 @@ const BillsListSection = ({
     handleAddBill,
     getCategoryIcon,
     selectedAllButtonStyle,
-    defaultAllButtonStyle
+    defaultAllButtonStyle,
+    rowClassName
 }) => {
 
     return (
@@ -76,6 +77,7 @@ const BillsListSection = ({
                 columns={columns}
                 dataSource={tableDataSource}
                 rowKey={record => record.id || `${record.name}-${record.dueDate}`} // Ensure unique keys
+                rowClassName={rowClassName}
                 pagination={false}
                 scroll={{ x: 730 }}
                 size="middle"
@@ -102,6 +104,7 @@ const BillsListSection = ({
 BillsListSection.defaultProps = {
   handleAddBill: () => console.warn("handleAddBill handler not provided to BillsListSection"),
   getCategoryIcon: () => null, // Provide a default fallback for the icon function
+  rowClassName: () => ''
 };
 
 


### PR DESCRIPTION
## Summary
- add fade-out animation CSS for bill rows
- allow BillsListSection to accept a rowClassName prop
- fade table row before marking a bill paid in CombinedBillsOverview

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*