### PR TITLE
Fix due balance and net position calculations

### DIFF
--- a/src/components/FinancialSummary/FinancialOverviewCards/DueBalanceCard.jsx
+++ b/src/components/FinancialSummary/FinancialOverviewCards/DueBalanceCard.jsx
@@ -35,17 +35,14 @@ const formatCurrency = (value) => {
 
 const DueBalanceCard = ({ isMobile, styles, isComponentLoading }) => {
   const {
-    currentDueAmt,
+    dueBalanceTotal,
     totalCreditCardBalance,
     hasAnyPastDueBills,
     pastDueAmountFromPreviousMonths,
   } = useContext(FinanceContext);
 
-  const combinedTotalDue = (currentDueAmt ?? 0) + (totalCreditCardBalance ?? 0);
-  const showDueWarning =
-    (currentDueAmt ?? 0) > 0 ||
-    (totalCreditCardBalance ?? 0) > 0 ||
-    hasAnyPastDueBills;
+  const combinedTotalDue = dueBalanceTotal ?? 0;
+  const showDueWarning = combinedTotalDue > 0;
 
   const dueCardIcon = showDueWarning ? (
     <IconFlagFilled size={styles.iconSize.standard} />

--- a/src/components/FinancialSummary/FinancialOverviewCards/NetPositionCard.jsx
+++ b/src/components/FinancialSummary/FinancialOverviewCards/NetPositionCard.jsx
@@ -28,13 +28,12 @@ const formatCurrencySuperscript = (value) => {
 };
 
 const NetPositionCard = ({ isMobile, styles, isComponentLoading }) => {
-  const { bankBalance, totalCreditCardBalance } = useContext(FinanceContext);
-  // Net position is the bank balance minus outstanding credit card debt.
-  // We no longer subtract unpaid bills so that paying a bill permanently
-  // decreases the net position as the bank balance updates.
+  const { bankBalance, dueBalanceTotal } = useContext(FinanceContext);
+  // Net position is the bank balance minus all amounts currently due
+  // (bills, Bill Prep items, and credit card balances).
   const grandTotal =
-    bankBalance !== null && totalCreditCardBalance !== null
-      ? bankBalance - totalCreditCardBalance
+    bankBalance !== null && dueBalanceTotal !== null
+      ? bankBalance - dueBalanceTotal
       : null;
   const grandTotalIsNegative = grandTotal !== null && grandTotal < 0;
 

--- a/src/contexts/FinanceContext.jsx
+++ b/src/contexts/FinanceContext.jsx
@@ -109,6 +109,19 @@ export const FinanceProvider = ({ children }) => {
     return !bill.isPaid && isCurrentMonth ? sum + Number(bill.amount || 0) : sum;
   }, 0);
 
+  // Calculate total amount due (current + past due + unpaid 'Bill Prep')
+  const dueBalanceTotal = bills.reduce((sum, bill) => {
+    if (bill.isPaid) return sum;
+    const dueDate = dayjs(bill.dueDate);
+    const isCurrentOrPast =
+      dueDate.isValid() && dueDate.isSameOrBefore(displayedMonth.endOf('month'));
+    const isBillPrep = bill.category?.toLowerCase() === 'bill prep';
+
+    return isCurrentOrPast || isBillPrep
+      ? sum + Number(bill.amount || 0)
+      : sum;
+  }, 0) + totalCreditCardBalance;
+
   // --- Month Navigation Functions ---
   const goToPreviousMonth = useCallback(() => {
     setDisplayedMonth(prev => prev.subtract(1, 'month'));
@@ -445,6 +458,7 @@ export const FinanceProvider = ({ children }) => {
 
     // Computed values
     totalCreditCardBalance,
+    dueBalanceTotal,
     hasAnyPastDueBills,
     pastDueAmountFromPreviousMonths,
     currentDueAmt,


### PR DESCRIPTION
## Summary
- compute full due balance in context (current month + past due + Bill Prep + CC debt)
- show updated due balance in overview card
- calculate net position using new due balance total

## Testing
- `npm run lint` *(fails: Do not access Object.prototype method 'hasOwnProperty' from target object, etc.)*