### PR TITLE
Add prompt for applying bill edits to future entries

### DIFF
--- a/src/components/BillsList/BillsList.jsx
+++ b/src/components/BillsList/BillsList.jsx
@@ -17,7 +17,7 @@ const BillsList = ({ loading: propLoading }) => {
   const [isEditModalVisible, setIsEditModalVisible] = useState(false);
   const [editingBill, setEditingBill] = useState(null);
   // Use context for data and actions
-  const { bills, loading: contextLoading, deleteBill, updateBill, addBill } = useContext(FinanceContext);
+  const { bills, loading: contextLoading, deleteBill, updateBill, addBill, updateBillWithFuture } = useContext(FinanceContext);
 
   // Use context loading state primarily, but allow prop override if needed
   const isLoading = propLoading !== undefined ? propLoading : contextLoading;
@@ -36,11 +36,17 @@ const BillsList = ({ loading: propLoading }) => {
 
   // Function to handle submission from the modal (calls context updateBill/addBill)
   const handleModalSubmit = async (values) => {
+      const { applyToFuture = {}, ...billValues } = values;
       let result;
       if (editingBill) {
-          result = await updateBill(editingBill, values); // Use context updateBill
+          const fields = Object.entries(applyToFuture).filter(([,v]) => v).map(([k]) => k);
+          if (fields.length > 0) {
+              result = await updateBillWithFuture(editingBill, billValues, fields);
+          } else {
+              result = await updateBill(editingBill, billValues); // Use context updateBill
+          }
       } else {
-          result = await addBill(values); // Use context addBill
+          result = await addBill(billValues); // Use context addBill
       }
       if (result) { // Context functions should return truthy on success
           setIsEditModalVisible(false);

--- a/src/components/BillsList/DashboardBillsList.jsx
+++ b/src/components/BillsList/DashboardBillsList.jsx
@@ -24,6 +24,7 @@ const DashboardBillsList = ({
     loading: contextLoading,
     deleteBill,
     updateBill,
+    updateBillWithFuture,
     addBill
   } = useContext(FinanceContext);
 
@@ -41,11 +42,17 @@ const DashboardBillsList = ({
   };
 
   const handleModalSubmit = async (values) => {
+    const { applyToFuture = {}, ...billValues } = values;
     let result;
     if (editingBill) {
-      result = await updateBill(editingBill, values);
+      const fields = Object.entries(applyToFuture).filter(([,v]) => v).map(([k]) => k);
+      if (fields.length > 0) {
+        result = await updateBillWithFuture(editingBill, billValues, fields);
+      } else {
+        result = await updateBill(editingBill, billValues);
+      }
     } else {
-      result = await addBill(values);
+      result = await addBill(billValues);
     }
     if (result) {
       setIsEditModalVisible(false);

--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
@@ -101,7 +101,7 @@ const getCategoryColor = (category) => {
 const CombinedBillsOverview = ({ style }) => {
     // Context and State (Remains the same)
     const {
-        loading, error, deleteBill, updateBill, addBill,
+        loading, error, deleteBill, updateBill, updateBillWithFuture, addBill,
         displayedMonth, goToPreviousMonth, goToNextMonth, bills,
     } = useContext(FinanceContext);
     const [isModalVisible, setIsModalVisible] = useState(false); // For EditBillModal
@@ -178,8 +178,19 @@ const CombinedBillsOverview = ({ style }) => {
          setEditingBill(record);
          setIsModalVisible(true);
      };
-     const handleModalSubmit = async (values) => {
-         let result = editingBill ? await updateBill(editingBill, values) : await addBill(values);
+    const handleModalSubmit = async (values) => {
+         const { applyToFuture = {}, ...billValues } = values;
+         let result;
+         if (editingBill) {
+             const fields = Object.entries(applyToFuture).filter(([,v]) => v).map(([k]) => k);
+             if (fields.length > 0) {
+                 result = await updateBillWithFuture(editingBill, billValues, fields);
+             } else {
+                 result = await updateBill(editingBill, billValues);
+             }
+         } else {
+             result = await addBill(billValues);
+         }
          if (result) { setIsModalVisible(false); setEditingBill(null); }
      };
     const handleTogglePaid = async (record) => {


### PR DESCRIPTION
## Summary
- prompt user in EditBillModal when changing amount, due date or category
- allow passing `applyToFuture` choice to parent components
- update BillsList, DashboardBillsList and CombinedBillsOverview to use new context helper
- add `updateBillWithFuture` helper in FinanceContext to propagate changes to future recurring bills

## Testing
- `npm run lint` *(fails: various existing lint errors)*