### PR TITLE
Reduce All Categories button size on mobile

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -652,6 +652,13 @@ textarea {
     width: 12px !important;
     height: 12px !important;
   }
+
+  /* Smaller 'All Categories' button */
+  .all-categories-btn {
+    height: 20px !important;
+    padding: 0 6px !important;
+    font-size: 0.75rem !important;
+  }
   
   /* Financial overview cards */
   .financial-overview-row {

--- a/src/components/FinancialSummary/CombinedBillsOverview/BillsListSection.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/BillsListSection.jsx
@@ -32,7 +32,13 @@ const BillsListSection = ({
                     {/* Filter controls */}
                     <Space align="center">
                         <Text strong style={{ color: 'var(--neutral-600)', whiteSpace: 'nowrap' }}> Filter by: </Text>
-                        <Button size="small" type="default" onClick={() => setSelectedCategory('All')} style={selectedCategory === 'All' ? selectedAllButtonStyle : defaultAllButtonStyle} >
+                        <Button
+                            size="small"
+                            type="default"
+                            className="all-categories-btn"
+                            onClick={() => setSelectedCategory('All')}
+                            style={selectedCategory === 'All' ? selectedAllButtonStyle : defaultAllButtonStyle}
+                        >
                             All Categories
                         </Button>
                     </Space>


### PR DESCRIPTION
## Summary
- add a CSS class to the "All Categories" button
- style the button for smaller size on mobile screens

## Testing
- `npm run lint` *(fails: no-unused-vars and other issues)*
- `npm run build`