### PR TITLE
Add desktop action menu for bills

### DIFF
--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
@@ -128,6 +128,13 @@
     gap: var(--space-12); /* Was 12px */
 }
 
+/* Wrapper for amount and desktop action menu */
+.bill-amount-wrapper {
+    display: flex;
+    align-items: center;
+    gap: var(--space-8);
+}
+
 .bill-name {
     font-size: 14px; /* Specific font size, close to --font-size-sm (0.875rem) */
     font-weight: 600;
@@ -144,6 +151,30 @@
     color: var(--neutral-900);
     line-height: 1;
     flex-shrink: 0;
+}
+
+/* Three-dot menu trigger (desktop only) */
+
+.bill-action-dropdown-trigger.ant-btn {
+    padding: 4px;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--neutral-500);
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    opacity: 1;
+    pointer-events: auto;
+    transition: color 0.2s ease;
+    margin-left: var(--space-4);
+    flex-shrink: 0;
+}
+
+.bill-action-dropdown-trigger.ant-btn:hover {
+    color: var(--primary-600);
 }
 
 .bill-details-row {
@@ -202,6 +233,10 @@
 
     .bill-amount {
         font-size: 13px; /* Specific mobile font size */
+    }
+
+    .bill-action-dropdown-trigger {
+        display: none !important;
     }
 
     .bill-due-status {

--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
@@ -192,27 +192,29 @@ const EnhancedBillRow = ({
             className={`enhanced-bill-row ${rowClassName ? rowClassName(record) : ''}`}
             onClick={handleRowClick}
         >
-            {/* Slide Actions Background - Always present but hidden */}
-            <div className="slide-actions-background">
-                <button 
-                    className="slide-action edit-action"
-                    onTouchEnd={(e) => handleActionClick('edit', e)}
-                    onClick={(e) => handleActionClick('edit', e)}
-                    aria-label="Edit bill"
-                >
-                    <IconEdit size={18} />
-                    <span>Edit</span>
-                </button>
-                <button 
-                    className="slide-action delete-action"
-                    onTouchEnd={(e) => handleActionClick('delete', e)}
-                    onClick={(e) => handleActionClick('delete', e)}
-                    aria-label="Delete bill"
-                >
-                    <IconTrash size={18} />
-                    <span>Delete</span>
-                </button>
-            </div>
+            {/* Slide Actions Background - mobile only */}
+            {isMobile && (
+                <div className="slide-actions-background">
+                    <button
+                        className="slide-action edit-action"
+                        onTouchEnd={(e) => handleActionClick('edit', e)}
+                        onClick={(e) => handleActionClick('edit', e)}
+                        aria-label="Edit bill"
+                    >
+                        <IconEdit size={18} />
+                        <span>Edit</span>
+                    </button>
+                    <button
+                        className="slide-action delete-action"
+                        onTouchEnd={(e) => handleActionClick('delete', e)}
+                        onClick={(e) => handleActionClick('delete', e)}
+                        aria-label="Delete bill"
+                    >
+                        <IconTrash size={18} />
+                        <span>Delete</span>
+                    </button>
+                </div>
+            )}
 
             {/* Main Row Content - This slides to reveal actions */}
             <div 
@@ -242,12 +244,35 @@ const EnhancedBillRow = ({
                     {/* Top Row: Name and Amount */}
                     <div className="bill-main-row">
                         <Text strong className="bill-name">{record.name}</Text>
-                        <Text strong className="bill-amount">
-                            ${Number(record.amount).toLocaleString('en-US', { 
-                                minimumFractionDigits: 2, 
-                                maximumFractionDigits: 2 
-                            })}
-                        </Text>
+                        <div className="bill-amount-wrapper">
+                            <Text strong className="bill-amount">
+                                ${Number(record.amount).toLocaleString('en-US', {
+                                    minimumFractionDigits: 2,
+                                    maximumFractionDigits: 2
+                                })}
+                            </Text>
+                            {!isMobile && (
+                                <Dropdown
+                                    menu={{
+                                        items: [
+                                            { key: 'edit', icon: <IconEdit size={16} />, label: 'Edit', onClick: () => onEdit(record) },
+                                            { key: 'delete', icon: <IconTrash size={16} />, label: 'Delete', danger: true, onClick: () => onDelete(record) }
+                                        ],
+                                        onClick: e => e.domEvent.stopPropagation()
+                                    }}
+                                    trigger={[ 'click' ]}
+                                    placement="bottomRight"
+                                >
+                                    <Button
+                                        className="bill-action-dropdown-trigger"
+                                        type="text"
+                                        size="small"
+                                        icon={<IconDotsVertical size={16} />}
+                                        onClick={e => e.stopPropagation()}
+                                    />
+                                </Dropdown>
+                            )}
+                        </div>
                     </div>
 
                     {/* Bottom Row: Category and Due Status */}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -4,9 +4,9 @@ const handleApiError = async (response) => {
     let errorBody = null;
     const contentType = response.headers.get("content-type");
     if (contentType && contentType.includes("application/json")) {
-        try { errorBody = await response.json(); } catch {}
+        try { errorBody = await response.json(); } catch { /* ignore */ }
     } else {
-        try { errorBody = await response.text(); } catch {}
+        try { errorBody = await response.text(); } catch { /* ignore */ }
     }
     console.error("API request failed:", response.status, response.statusText, errorBody);
     let errorMessage = `HTTP error! status: ${response.status} ${response.statusText}`;


### PR DESCRIPTION
## Summary
- add a desktop dropdown menu in CombinedBillsOverview
- hide swipe actions on desktop
- style dropdown trigger and wrapper
- fix empty catch blocks in `api.js`
- show the desktop action button by default

## Testing
- `npm run lint`
- `npm test`
