### PR TITLE
Add desktop actions menu visibility

### DIFF
--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
@@ -153,7 +153,7 @@
     flex-shrink: 0;
 }
 
-/* Three-dot menu trigger (desktop only) */
+/* Three-dot menu trigger (desktop only, always visible) */
 .bill-action-dropdown-trigger.ant-btn {
     padding: 4px;
     width: 24px;
@@ -165,16 +165,11 @@
     background: transparent !important;
     border: none !important;
     box-shadow: none !important;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.2s ease-in-out, color 0.2s ease;
-    margin-left: var(--space-4);
-    flex-shrink: 0;
-}
-
-.enhanced-bill-row:hover .bill-action-dropdown-trigger {
     opacity: 1;
     pointer-events: auto;
+    transition: color 0.2s ease;
+    margin-left: var(--space-4);
+    flex-shrink: 0;
 }
 
 .bill-action-dropdown-trigger.ant-btn:hover {


### PR DESCRIPTION
## Summary
- always show the three-dot action menu on desktop bills

## Testing
- `npm run lint`
- `npm test`
