### PR TITLE
Fix category tag alignment

### DIFF
--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
@@ -132,7 +132,7 @@
 .bill-amount-section {
     display: flex;
     justify-content: space-between;
-    align-items: flex-start;
+    align-items: center;
     gap: var(--space-8);
 }
 
@@ -183,12 +183,6 @@
     color: var(--primary-600);
 }
 
-.bill-details-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: var(--space-8); /* Was 8px */
-}
 
 .bill-due-status {
     font-size: 12px; /* Specific font size, matches --font-size-xs (0.75rem) */
@@ -200,6 +194,11 @@
     color: var(--neutral-700);
     white-space: nowrap;
     flex-shrink: 0;
+}
+
+.bill-category-tag {
+    display: inline-flex;
+    align-items: center;
 }
 
 /* Fade animation for bill completion */

--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
@@ -256,6 +256,34 @@ const EnhancedBillRow = ({
                                     {renderDueIn(record.dueDate, record)}
                                 </div>
                             </div>
+                            {record.category && (
+                                <Tag
+                                    className="bill-category-tag"
+                                    style={{
+                                        margin: 0,
+                                        backgroundColor: 'transparent',
+                                        border: 'none',
+                                        fontSize: '0.75rem',
+                                        padding: '0 4px 0 0'
+                                    }}
+                                >
+                                    <span style={{
+                                        marginRight: '6px',
+                                        display: 'inline-flex',
+                                        alignItems: 'center'
+                                    }}>
+                                        {React.cloneElement(getCategoryIcon(record.category), {
+                                            size: 14,
+                                            style: { color: getCategoryColor(record.category).text }
+                                        })}
+                                    </span>
+                                    <span style={{
+                                        color: getCategoryColor(record.category).text
+                                    }}>
+                                        {record.category}
+                                    </span>
+                                </Tag>
+                            )}
                             <Dropdown
                                 menu={{
                                     items: [
@@ -278,36 +306,6 @@ const EnhancedBillRow = ({
                         </div>
                     </div>
 
-                    {/* Bottom Row: Category */}
-                    <div className="bill-details-row">
-                        {record.category && (
-                            <Tag
-                                style={{
-                                    margin: 0,
-                                    backgroundColor: 'transparent',
-                                    border: 'none',
-                                    fontSize: '0.75rem',
-                                    padding: '0 4px 0 0'
-                                }}
-                            >
-                                <span style={{ 
-                                    marginRight: '6px', 
-                                    display: 'inline-flex', 
-                                    alignItems: 'center' 
-                                }}>
-                                    {React.cloneElement(getCategoryIcon(record.category), { 
-                                        size: 14,
-                                        style: { color: getCategoryColor(record.category).text }
-                                    })}
-                                </span>
-                                <span style={{ 
-                                    color: getCategoryColor(record.category).text
-                                }}>
-                                    {record.category}
-                                </span>
-                            </Tag>
-                        )}
-                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- keep bill info on one line by moving tag into the main row
- center items in `.bill-amount-section`
- drop obsolete `.bill-details-row` styling and add `.bill-category-tag`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6839f71520a0832383637759bdfd043b