### PR TITLE
Improve bill tag layout

### DIFF
--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
@@ -131,7 +131,6 @@
 /* Wrapper for amount, due date and action menu */
 .bill-amount-section {
     display: flex;
-    justify-content: space-between;
     align-items: center;
     gap: var(--space-8);
 }
@@ -199,6 +198,7 @@
 .bill-category-tag {
     display: inline-flex;
     align-items: center;
+    white-space: nowrap;
 }
 
 /* Fade animation for bill completion */
@@ -249,6 +249,11 @@
         font-size: 11px; /* Specific mobile font size */
         margin-top: 4px;
         padding: 1px var(--space-4); /* Vertical 1px custom, horizontal uses variable */
+    }
+
+    .bill-amount-section {
+        flex-wrap: wrap;
+        gap: var(--space-4);
     }
 
     /* Slide actions mobile optimization */


### PR DESCRIPTION
## Summary
- tweak bill amount wrapper spacing
- prevent bill tag wrapping and allow responsive wrapping on narrow screens

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6839f92371e88323bc9c3cca1d174638