### PR TITLE
Fix bills list tag alignment

### DIFF
--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
@@ -128,6 +128,15 @@
     gap: var(--space-12); /* Was 12px */
 }
 
+/* Wrapper for bill name and category tag */
+.bill-name-and-category {
+    display: flex;
+    align-items: center;
+    gap: var(--space-8);
+    flex: 1;
+    min-width: 0;
+}
+
 /* Wrapper for amount, due date and action menu */
 .bill-amount-section {
     display: flex;
@@ -231,6 +240,10 @@
 
     .bill-main-row {
         gap: var(--space-8); /* Was 8px */
+    }
+
+    .bill-name-and-category {
+        gap: var(--space-4);
     }
 
     .bill-name {

--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
@@ -243,19 +243,8 @@ const EnhancedBillRow = ({
                 <div className="bill-content">
                     {/* Top Row: Name and Amount */}
                     <div className="bill-main-row">
-                        <Text strong className="bill-name">{record.name}</Text>
-                        <div className="bill-amount-section">
-                            <div className="amount-and-due">
-                                <Text strong className="bill-amount">
-                                    ${Number(record.amount).toLocaleString('en-US', {
-                                        minimumFractionDigits: 2,
-                                        maximumFractionDigits: 2
-                                    })}
-                                </Text>
-                                <div className="bill-due-status">
-                                    {renderDueIn(record.dueDate, record)}
-                                </div>
-                            </div>
+                        <div className="bill-name-and-category">
+                            <Text strong className="bill-name">{record.name}</Text>
                             {record.category && (
                                 <Tag
                                     className="bill-category-tag"
@@ -284,6 +273,19 @@ const EnhancedBillRow = ({
                                     </span>
                                 </Tag>
                             )}
+                        </div>
+                        <div className="bill-amount-section">
+                            <div className="amount-and-due">
+                                <Text strong className="bill-amount">
+                                    ${Number(record.amount).toLocaleString('en-US', {
+                                        minimumFractionDigits: 2,
+                                        maximumFractionDigits: 2
+                                    })}
+                                </Text>
+                                <div className="bill-due-status">
+                                    {renderDueIn(record.dueDate, record)}
+                                </div>
+                            </div>
                             <Dropdown
                                 menu={{
                                     items: [


### PR DESCRIPTION
## Summary
- align bill category tags next to bill names
- add CSS styles for new bill name/category wrapper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6839fb7bdffc832383630b30c31b568e