### PR TITLE
Improve mobile tap area for finance feed

### DIFF
--- a/src/components/FinanceFeed/MobileFinanceFeed.jsx
+++ b/src/components/FinanceFeed/MobileFinanceFeed.jsx
@@ -282,12 +282,19 @@ const MobileFinanceFeed = () => {
           )}
         />
         {pastDueBills.length > 4 && (
-          <div className="show-more-container">
+          <div
+            className="show-more-container"
+            onClick={() => toggleShowAll('pastDue')}
+            style={{ cursor: 'pointer' }}
+          >
             <Button
               type="link"
               className="show-more-button"
               style={{ color: '#F1476F' }}
-              onClick={() => toggleShowAll('pastDue')}
+              onClick={(e) => {
+                e.stopPropagation();
+                toggleShowAll('pastDue');
+              }}
             >
               {showAll.pastDue ? 'Show Less' : 'Show All'}
             </Button>
@@ -340,12 +347,19 @@ const MobileFinanceFeed = () => {
           )}
         />
         {billPrep.length > 4 && (
-          <div className="show-more-container">
+          <div
+            className="show-more-container"
+            onClick={() => toggleShowAll('billPrep')}
+            style={{ cursor: 'pointer' }}
+          >
             <Button
               type="link"
               className="show-more-button"
               style={{ color: '#1890FF' }}
-              onClick={() => toggleShowAll('billPrep')}
+              onClick={(e) => {
+                e.stopPropagation();
+                toggleShowAll('billPrep');
+              }}
             >
               {showAll.billPrep ? 'Show Less' : 'Show All'}
             </Button>
@@ -473,12 +487,19 @@ const MobileFinanceFeed = () => {
           )}
         />
         {upcoming.length > 4 && (
-          <div className="show-more-container">
+          <div
+            className="show-more-container"
+            onClick={() => toggleShowAll('upcoming')}
+            style={{ cursor: 'pointer' }}
+          >
             <Button
               type="link"
               className="show-more-button"
               style={{ color: '#0066FF' }}
-              onClick={() => toggleShowAll('upcoming')}
+              onClick={(e) => {
+                e.stopPropagation();
+                toggleShowAll('upcoming');
+              }}
             >
               {showAll.upcoming ? 'Show Less' : 'Show All'}
             </Button>
@@ -532,12 +553,19 @@ const MobileFinanceFeed = () => {
           )}
         />
         {recentActivity.length > 4 && (
-          <div className="show-more-container">
+          <div
+            className="show-more-container"
+            onClick={() => toggleShowAll('recentActivity')}
+            style={{ cursor: 'pointer' }}
+          >
             <Button
               type="link"
               className="show-more-button"
-              style={{color: '#722ED1'}}
-              onClick={() => toggleShowAll('recentActivity')}
+              style={{ color: '#722ED1' }}
+              onClick={(e) => {
+                e.stopPropagation();
+                toggleShowAll('recentActivity');
+              }}
             >
               {showAll.recentActivity ? 'Show Less' : 'Show All'}
             </Button>

--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
@@ -625,15 +625,22 @@ const CombinedBillsOverview = ({ style }) => {
 
                     {/* Footer */}
                     {billsDueInDisplayedMonth.length > 0 && paidVisibleCount > 0 && (
-                        <div style={{ 
-                            textAlign: 'center', 
-                            borderTop: '1px solid var(--neutral-200)',
-                            padding: 'var(--space-12) var(--space-20)'
-                        }}>
+                        <div
+                            style={{
+                                textAlign: 'center',
+                                borderTop: '1px solid var(--neutral-200)',
+                                padding: 'var(--space-12) var(--space-20)',
+                                cursor: 'pointer'
+                            }}
+                            onClick={() => setShowPaidBills(prev => !prev)}
+                        >
                             <Button
                                 type="text"
                                 icon={showPaidBills ? <IconEyeOff size={16} /> : <IconEye size={16} />}
-                                onClick={() => setShowPaidBills(prev => !prev)}
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    setShowPaidBills(prev => !prev);
+                                }}
                                 style={{ color: 'var(--neutral-600)' }}
                             >
                                 {showPaidBills ? 'Hide Paid Bills' : 'Show All Bills'}


### PR DESCRIPTION
## Summary
- make the 'Show All' rows in the mobile finance feed clickable across the width
- do the same for the combined bills overview footer

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6839ffdaa49c8323aa6521dccf782bf0