### PR TITLE
Fix past due feed ignoring Bill Prep

### DIFF
--- a/src/components/FinancialSummary/FinancialOverviewCards/DueBalanceCard.jsx
+++ b/src/components/FinancialSummary/FinancialOverviewCards/DueBalanceCard.jsx
@@ -55,8 +55,8 @@ const DueBalanceCard = ({ isMobile, styles, isComponentLoading }) => {
     const cc = formatCurrency(totalCreditCardBalance);
     let subtext = '';
 
-    if (hasAnyPastDueBills && hasCC) subtext = `Incl. ${past} in Bill Prep | ${cc} CC`;
-    else if (hasAnyPastDueBills) subtext = `Incl. ${past} in Bill Prep`;
+    if (hasAnyPastDueBills && hasCC) subtext = `Incl. ${past} Past Due | ${cc} CC`;
+    else if (hasAnyPastDueBills) subtext = `Incl. ${past} Past Due`;
     else if (hasCC) subtext = `Incl. ${cc} CC`;
 
     return subtext ? (

--- a/src/contexts/FinanceContext.jsx
+++ b/src/contexts/FinanceContext.jsx
@@ -60,7 +60,13 @@ export const FinanceProvider = ({ children }) => {
 
   const pastDueBills = bills.filter(bill => {
     const dueDate = dayjs(bill.dueDate);
-    return !bill.isPaid && dueDate.isValid() && dueDate.isBefore(dayjs(), 'day');
+    const isBillPrep = bill.category?.toLowerCase() === 'bill prep';
+    return (
+      !bill.isPaid &&
+      !isBillPrep &&
+      dueDate.isValid() &&
+      dueDate.isBefore(dayjs(), 'day')
+    );
   });
 
   const totalCreditCardBalanceAll = creditCards.reduce((sum, card) => sum + Number(card.balance || 0), 0);


### PR DESCRIPTION
## Summary
- exclude `Bill Prep` transactions when determining `pastDueBills`
- update Due Balance card subtext to reference past due totals

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683a0378f70483238ac1575857c03c3e