### PR TITLE
Fix bills card footer visibility

### DIFF
--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
@@ -624,16 +624,20 @@ const CombinedBillsOverview = ({ style }) => {
                     </div>
 
                     {/* Footer */}
-                    {billsDueInDisplayedMonth.length > 0 && paidVisibleCount > 0 && (
-                        <div
-                            style={{
-                                textAlign: 'center',
-                                borderTop: '1px solid var(--neutral-200)',
-                                padding: 'var(--space-12) var(--space-20)',
-                                cursor: 'pointer'
-                            }}
-                            onClick={() => setShowPaidBills(prev => !prev)}
-                        >
+                    <div
+                        style={{
+                            textAlign: 'center',
+                            borderTop: '1px solid var(--neutral-200)',
+                            padding: 'var(--space-12) var(--space-20)',
+                            cursor: 'pointer'
+                        }}
+                        onClick={
+                            billsDueInDisplayedMonth.length > 0 && paidVisibleCount > 0
+                                ? () => setShowPaidBills(prev => !prev)
+                                : undefined
+                        }
+                    >
+                        {billsDueInDisplayedMonth.length > 0 && paidVisibleCount > 0 && (
                             <Button
                                 type="text"
                                 icon={showPaidBills ? <IconEyeOff size={16} /> : <IconEye size={16} />}
@@ -645,8 +649,8 @@ const CombinedBillsOverview = ({ style }) => {
                             >
                                 {showPaidBills ? 'Hide Paid Bills' : 'Show All Bills'}
                             </Button>
-                        </div>
-                    )}
+                        )}
+                    </div>
                 </Spin>
 
                 {/* Modals */}


### PR DESCRIPTION
## Summary
- always render the bills footer container
- only render the "Show All Bills" button when bills exist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683a0afec37883238180e78542345dd3