### PR TITLE
Enable numeric keypad for amount fields

### DIFF
--- a/src/components/PopUpModals/AddCreditCardModal.jsx
+++ b/src/components/PopUpModals/AddCreditCardModal.jsx
@@ -122,6 +122,8 @@ const AddCreditCardModal = ({ open, onClose, onSubmit }) => {
             parser={(value) => value?.replace(/\$\s?|(,*)/g, '') ?? ''}
             style={{ width: '100%', height: inputHeight, borderRadius: '8px' }}
             placeholder="0.00"
+            inputMode="decimal"
+            pattern="[0-9]*"
           />
         </Form.Item>
 

--- a/src/components/PopUpModals/BankBalanceEditModal.jsx
+++ b/src/components/PopUpModals/BankBalanceEditModal.jsx
@@ -173,6 +173,8 @@ export default function BankBalanceEditModal({ open, onClose }) {
                 precision={2} // Allow up to 2 decimal places
                 controls={false} // Hide spinner controls
                 style={{ width: '100%' }} // Ensure input takes full width
+                inputMode="decimal"
+                pattern="[0-9]*"
               />
             </Form.Item>
 

--- a/src/components/PopUpModals/EditBillModal.jsx
+++ b/src/components/PopUpModals/EditBillModal.jsx
@@ -237,6 +237,8 @@ const UnifiedEditBillModal = ({ open, onCancel, onSubmit, bill }) => {
                           formatter={(value) => value ? Number(value).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : ''}
                           parser={(value) => value?.replace(/,/g, '') || ''}
                           controls={false}
+                          inputMode="decimal"
+                          pattern="[0-9]*"
                         />
                       </div>
                     </div>

--- a/src/components/PopUpModals/EditCreditCardModal.jsx
+++ b/src/components/PopUpModals/EditCreditCardModal.jsx
@@ -133,6 +133,8 @@ const EditCreditCardModal = ({ open, onClose, onSubmit, cardData }) => {
             parser={(value) => value?.replace(/\$\s?|(,*)/g, '') ?? ''}
             style={{ width: '100%', height: inputHeight, borderRadius: '8px' }}
             placeholder="Enter the current balance"
+            inputMode="decimal"
+            pattern="[0-9]*"
           />
         </Form.Item>
       </Form>

--- a/src/components/PopUpModals/MultiBillModal.jsx
+++ b/src/components/PopUpModals/MultiBillModal.jsx
@@ -213,6 +213,8 @@ export default function MultiBillModal({ open, onClose }) {
                           min={0}
                           precision={2}
                           className="bill-input"
+                          inputMode="decimal"
+                          pattern="[0-9]*"
                         />
                       </Form.Item>
                       


### PR DESCRIPTION
## Summary
- ensure numeric keypad appears for any monetary input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683a1c46e3448323ba64e65b523c1a89