### PR TITLE
Fix mobile layout for skeleton cards

### DIFF
--- a/src/components/skeletons/FinancialOverviewSkeleton/FinancialOverviewSkeleton.jsx
+++ b/src/components/skeletons/FinancialOverviewSkeleton/FinancialOverviewSkeleton.jsx
@@ -32,7 +32,7 @@ const FinancialOverviewSkeleton = () => {
     <Row gutter={[8, 8]} style={{ marginBottom: 8 }} className="financial-overview-skeleton">
       {/* Create 3 placeholder columns */}
       {[1, 2, 3].map(i => (
-        <Col xs={8} sm={8} md={8} key={i}>
+        <Col xs={24} sm={8} md={8} key={i}>
           {/* Use Ant Design Card and Skeleton components */}
           <Card style={cardStyle} bodyStyle={bodyStyle} className="skeleton-card">
             {/* Skeleton for the title/icon area */}


### PR DESCRIPTION
## Summary
- stack FinancialOverviewSkeleton columns at xs breakpoint to keep them inside card containers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683a2467288c8323861a6a9a304e6620