### PR TITLE
Fix financial overview skeleton layout

### DIFF
--- a/src/components/skeletons/FinancialOverviewSkeleton/FinancialOverviewSkeleton.css
+++ b/src/components/skeletons/FinancialOverviewSkeleton/FinancialOverviewSkeleton.css
@@ -1,1 +1,2 @@
 /* Styles for FinancialOverviewSkeleton */
+

--- a/src/components/skeletons/FinancialOverviewSkeleton/FinancialOverviewSkeleton.jsx
+++ b/src/components/skeletons/FinancialOverviewSkeleton/FinancialOverviewSkeleton.jsx
@@ -32,7 +32,7 @@ const FinancialOverviewSkeleton = () => {
     <Row gutter={[8, 8]} style={{ marginBottom: 8 }} className="financial-overview-skeleton">
       {/* Create 3 placeholder columns */}
       {[1, 2, 3].map(i => (
-        <Col xs={24} sm={8} md={8} key={i}>
+        <Col xs={8} sm={8} md={8} key={i}>
           {/* Use Ant Design Card and Skeleton components */}
           <Card style={cardStyle} bodyStyle={bodyStyle} className="skeleton-card">
             {/* Skeleton for the title/icon area */}
@@ -54,24 +54,12 @@ const FinancialOverviewSkeleton = () => {
         </Col>
       ))}
       
-      {/* Add styles for mobile-specific adjustments */}
+      {/* Ensure skeleton elements fit within cards on all screen sizes */}
       <style jsx>{`
-        .financial-overview-skeleton .skeleton-title {
-          width: 60%; /* Default desktop width */
-        }
-        
+        .financial-overview-skeleton .skeleton-title,
         .financial-overview-skeleton .skeleton-value {
-          width: 80%; /* Default desktop width */
-        }
-        
-        @media (max-width: 768px) {
-          .financial-overview-skeleton .skeleton-title {
-            width: 50% !important; /* Mobile width */
-          }
-          
-          .financial-overview-skeleton .skeleton-value {
-            width: 70% !important; /* Mobile width */
-          }
+          width: 100% !important;
+          max-width: 100% !important;
         }
       `}</style>
     </Row>


### PR DESCRIPTION
## Summary
- keep skeleton components in one row on mobile
- ensure skeleton inputs stay inside their cards

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683a2811f54483239822ad20c76bf750