### PR TITLE
Fix recurring bill date comparisons

### DIFF
--- a/server/routes/bills.js
+++ b/server/routes/bills.js
@@ -2,6 +2,8 @@
 const express = require('express');
 const db = require('../db');
 const dayjs = require('dayjs');
+const isSameOrBefore = require('dayjs/plugin/isSameOrBefore');
+dayjs.extend(isSameOrBefore);
 
 const router = express.Router();
 


### PR DESCRIPTION
## Summary
- extend `dayjs` with `isSameOrBefore` plugin in `bills` routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683b9a2060f88323ae7c80682ceae6b3