### PR TITLE
Fix DB errors by running migrations on start

### DIFF
--- a/server/runMigrations.js
+++ b/server/runMigrations.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const db = require('./db');
+
+async function runMigrations() {
+  const migrationsDir = path.join(__dirname, 'migrations');
+  const files = fs.readdirSync(migrationsDir)
+    .filter(f => f.endsWith('.sql'))
+    .sort();
+
+  await db.query(`CREATE TABLE IF NOT EXISTS migrations (
+    id SERIAL PRIMARY KEY,
+    filename TEXT UNIQUE,
+    executed_at TIMESTAMP DEFAULT NOW()
+  )`);
+
+  for (const file of files) {
+    const already = await db.query('SELECT 1 FROM migrations WHERE filename = $1', [file]);
+    if (already.rows.length > 0) continue;
+
+    const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+    console.log(`Running migration ${file}`);
+    try {
+      await db.query(sql);
+      await db.query('INSERT INTO migrations (filename) VALUES ($1)', [file]);
+      console.log(`Migration ${file} complete`);
+    } catch (err) {
+      console.error(`Migration ${file} failed:`, err);
+      throw err;
+    }
+  }
+}
+
+module.exports = runMigrations;

--- a/server/server.js
+++ b/server/server.js
@@ -4,6 +4,7 @@ const express = require('express');
 const cors = require('cors');
 const path = require('path');
 const pool = require('./db'); // Import the database pool setup
+const runMigrations = require('./runMigrations');
 
 // Import route handlers
 const balanceRoutes = require('./routes/balance');
@@ -16,143 +17,154 @@ console.log('NODE_ENV:', process.env.NODE_ENV);
 console.log('Attempting to read PORT:', process.env.PORT);
 console.log('-----------------------------');
 
-const app = express();
-
-// --- Determine Port (Safer Parsing) ---
-let port = parseInt(process.env.PORT, 10);
-if (isNaN(port) || port <= 0) {
-    console.warn(`WARN: Invalid or missing PORT environment variable: "${process.env.PORT}". Defaulting to 4000 for local dev.`);
-    port = 4000;
-}
-const PORT = port;
-if (isNaN(PORT)) {
-   console.error("FATAL: Could not determine a valid PORT. Exiting.");
-   process.exit(1);
-}
-console.log(`INFO: Determined PORT: ${PORT}`);
-// --- End Port Determination ---
-
-// --- JSON body parsing middleware (MUST come before routes) ---
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
-
-// --- Very detailed request logging for debugging ---
-app.use((req, res, next) => {
-    console.log(`\n--- INCOMING REQUEST ${new Date().toISOString()} ---`);
-    console.log(`Method: ${req.method}`);
-    console.log(`URL: ${req.url}`);
-    console.log(`Path: ${req.path}`);
-    console.log(`Original URL: ${req.originalUrl}`);
-    console.log(`Query params:`, req.query);
-    console.log(`Headers:`, req.headers);
-    console.log(`Body:`, req.body);
-    console.log(`-------------------------------------------`);
-    next();
-});
-
-// --- CORS configuration (with permissive settings for debugging) ---
-app.use(cors({
-    origin: '*', // Allow all origins temporarily for debugging - RESTRICT THIS IN PRODUCTION
-    methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization'],
-    credentials: true
-}));
-
-// --- Test response header enhancement middleware (Optional) ---
-app.use((req, res, next) => {
-    const originalSend = res.send;
-    res.send = function(body) {
-        console.log(`Sending response for ${req.method} ${req.originalUrl}`);
-        return originalSend.call(this, body);
-    };
-    next();
-});
-
-// --- Basic test routes ---
-app.get('/', (req, res) => {
-    console.log('>>> Root route hit!');
-    res.status(200).send('Server is running. Try /api/ping to test API connectivity.');
-});
-
-app.get('/ping', (req, res) => {
-    console.log('>>> /ping route hit!');
-    res.status(200).json({ message: 'pong from root' });
-});
-
-// --- API root handler ---
-app.get('/api', (req, res) => {
-    console.log('>>> /api root route hit!');
-    res.status(200).json({ message: 'API is running' });
-});
-
-// --- Direct API test route ---
-app.get('/api/ping', (req, res) => {
-    console.log('>>> /api/ping route hit!');
-    res.status(200).json({ message: 'pong from api' });
-});
-
-// --- Main API Routes ---
-try {
-    console.log("INFO: Mounting /api/balance routes...");
-    app.use('/api/balance', balanceRoutes);
-
-    console.log("INFO: Mounting /api/bills routes...");
-    app.use('/api/bills', billsRoutes);
-
-    console.log("INFO: Mounting /api/master-bills routes...");
-    app.use('/api/master-bills', masterBillsRoutes);
-
-    console.log("INFO: Mounting /api/credit_cards routes...");
-    app.use('/api/credit_cards', creditCardsRoutes);
-
-    console.log("INFO: All API routes mounted successfully.");
-} catch (mountError) {
-    console.error("FATAL: Error during route mounting:", mountError);
-    process.exit(1);
-}
-
-// --- Health Check & DB Test Route ---
-app.get('/db-test', async (req, res, next) => {
+async function startServer() {
     try {
-        console.log('>>> DB test route hit!');
-        const timeResult = await pool.query('SELECT NOW()');
-        res.status(200).json({
-            dbTime: timeResult.rows[0].now,
-            message: 'Database connection successful'
-        });
-    } catch (error) {
-        console.error('Database test connection error:', error);
-        next(error);
+        await runMigrations();
+    } catch (err) {
+        console.error('FATAL: Error running migrations:', err);
+        process.exit(1);
     }
-});
 
-// Note: Removed explicit `app.options('/*', ...)` catch‑all because global CORS handles OPTIONS
+    const app = express();
 
-// --- 404 handler (must be after all specific routes) ---
-app.use((req, res) => {
-    console.log(`404: Route not found for ${req.method} ${req.originalUrl}`);
-    res.status(404).json({ error: 'Route not found' });
-});
+    // --- Determine Port (Safer Parsing) ---
+    let port = parseInt(process.env.PORT, 10);
+    if (isNaN(port) || port <= 0) {
+        console.warn(`WARN: Invalid or missing PORT environment variable: "${process.env.PORT}". Defaulting to 4000 for local dev.`);
+        port = 4000;
+    }
+    const PORT = port;
+    if (isNaN(PORT)) {
+        console.error("FATAL: Could not determine a valid PORT. Exiting.");
+        process.exit(1);
+    }
+    console.log(`INFO: Determined PORT: ${PORT}`);
+    // --- End Port Determination ---
 
-// --- Global error handler (must be the LAST app.use call) ---
-app.use((err, req, res, next) => {
-    console.error('--- Global Error Handler Triggered ---');
-    console.error('Route:', req.method, req.originalUrl);
-    console.error(err.stack || err);
-    console.error('------------------------------------');
+    // --- JSON body parsing middleware (MUST come before routes) ---
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: true }));
 
-    const statusCode = err.status || err.statusCode || 500;
-    const message = process.env.NODE_ENV === 'production'
-        ? 'An unexpected error occurred on the server.'
-        : err.message || 'An unexpected error occurred on the server.';
+    // --- Very detailed request logging for debugging ---
+    app.use((req, res, next) => {
+        console.log(`\n--- INCOMING REQUEST ${new Date().toISOString()} ---`);
+        console.log(`Method: ${req.method}`);
+        console.log(`URL: ${req.url}`);
+        console.log(`Path: ${req.path}`);
+        console.log(`Original URL: ${req.originalUrl}`);
+        console.log(`Query params:`, req.query);
+        console.log(`Headers:`, req.headers);
+        console.log(`Body:`, req.body);
+        console.log(`-------------------------------------------`);
+        next();
+    });
 
-    res.status(statusCode).json({ message });
-});
+    // --- CORS configuration (with permissive settings for debugging) ---
+    app.use(cors({
+        origin: '*', // Allow all origins temporarily for debugging - RESTRICT THIS IN PRODUCTION
+        methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
+        allowedHeaders: ['Content-Type', 'Authorization'],
+        credentials: true
+    }));
 
-// --- Server Startup ---
-app.listen(PORT, '0.0.0.0', () => {
-    console.log(`Server listening on 0.0.0.0:${PORT}`);
-});
+    // --- Test response header enhancement middleware (Optional) ---
+    app.use((req, res, next) => {
+        const originalSend = res.send;
+        res.send = function(body) {
+            console.log(`Sending response for ${req.method} ${req.originalUrl}`);
+            return originalSend.call(this, body);
+        };
+        next();
+    });
+
+    // --- Basic test routes ---
+    app.get('/', (req, res) => {
+        console.log('>>> Root route hit!');
+        res.status(200).send('Server is running. Try /api/ping to test API connectivity.');
+    });
+
+    app.get('/ping', (req, res) => {
+        console.log('>>> /ping route hit!');
+        res.status(200).json({ message: 'pong from root' });
+    });
+
+    // --- API root handler ---
+    app.get('/api', (req, res) => {
+        console.log('>>> /api root route hit!');
+        res.status(200).json({ message: 'API is running' });
+    });
+
+    // --- Direct API test route ---
+    app.get('/api/ping', (req, res) => {
+        console.log('>>> /api/ping route hit!');
+        res.status(200).json({ message: 'pong from api' });
+    });
+
+    // --- Main API Routes ---
+    try {
+        console.log("INFO: Mounting /api/balance routes...");
+        app.use('/api/balance', balanceRoutes);
+
+        console.log("INFO: Mounting /api/bills routes...");
+        app.use('/api/bills', billsRoutes);
+
+        console.log("INFO: Mounting /api/master-bills routes...");
+        app.use('/api/master-bills', masterBillsRoutes);
+
+        console.log("INFO: Mounting /api/credit_cards routes...");
+        app.use('/api/credit_cards', creditCardsRoutes);
+
+        console.log("INFO: All API routes mounted successfully.");
+    } catch (mountError) {
+        console.error("FATAL: Error during route mounting:", mountError);
+        process.exit(1);
+    }
+
+    // --- Health Check & DB Test Route ---
+    app.get('/db-test', async (req, res, next) => {
+        try {
+            console.log('>>> DB test route hit!');
+            const timeResult = await pool.query('SELECT NOW()');
+            res.status(200).json({
+                dbTime: timeResult.rows[0].now,
+                message: 'Database connection successful'
+            });
+        } catch (error) {
+            console.error('Database test connection error:', error);
+            next(error);
+        }
+    });
+
+    // Note: Removed explicit `app.options('/*', ...)` catch‑all because global CORS handles OPTIONS
+
+    // --- 404 handler (must be after all specific routes) ---
+    app.use((req, res) => {
+        console.log(`404: Route not found for ${req.method} ${req.originalUrl}`);
+        res.status(404).json({ error: 'Route not found' });
+    });
+
+    // --- Global error handler (must be the LAST app.use call) ---
+    app.use((err, req, res, next) => {
+        console.error('--- Global Error Handler Triggered ---');
+        console.error('Route:', req.method, req.originalUrl);
+        console.error(err.stack || err);
+        console.error('------------------------------------');
+
+        const statusCode = err.status || err.statusCode || 500;
+        const message = process.env.NODE_ENV === 'production'
+            ? 'An unexpected error occurred on the server.'
+            : err.message || 'An unexpected error occurred on the server.';
+
+        res.status(statusCode).json({ message });
+    });
+
+    // --- Server Startup ---
+    app.listen(PORT, '0.0.0.0', () => {
+        console.log(`Server listening on 0.0.0.0:${PORT}`);
+    });
+}
+
+startServer();
 
 // --- Process Event Handlers for better stability ---
 process.on('unhandledRejection', (reason, promise) => {


### PR DESCRIPTION
## Summary
- add a simple migration runner for the server
- wrap server startup in async function and run migrations before listening

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683b9f96a2408323ba3b18bc18df07b5