### PR TITLE
Fix due balance query with dedup

### DIFF
--- a/tests/due_balanceQuery.test.cjs
+++ b/tests/due_balanceQuery.test.cjs
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+const filePath = path.join(__dirname, '..', 'server', 'routes', 'due_balance.js');
+const content = fs.readFileSync(filePath, 'utf8');
+
+const distinctPattern = /SELECT\s+DISTINCT\s+b\.id,\s*b\.amount/i;
+const sumPattern = /SUM\(distinct_bills\.amount\)/i;
+
+assert.ok(distinctPattern.test(content), 'Query should select DISTINCT bill IDs');
+assert.ok(sumPattern.test(content), 'Query should sum from distinct set');
+
+console.log('All due_balance query tests passed.');
+


### PR DESCRIPTION
## Summary
- ensure due balance bills query deduplicates results
- add small unit test verifying query contains `SELECT DISTINCT` clause

## Testing
- `node tests/due_balanceQuery.test.cjs`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683bcdb7179c8323ba0110f0ae3a25eb