### PR TITLE
Fix positive amount validation in edit bill modal

### DIFF
--- a/src/components/PopUpModals/EditBillModal.jsx
+++ b/src/components/PopUpModals/EditBillModal.jsx
@@ -66,7 +66,10 @@ const UnifiedEditBillModal = ({ open, onCancel, onSubmit, bill }) => {
       : '';
 
   const parseAmount = (value) => {
-    const numeric = parseFloat((value || '').toString().replace(/,/g, ''));
+    if (value === '' || value === null || value === undefined) {
+      return '';
+    }
+    const numeric = parseFloat(value.toString().replace(/,/g, ''));
     return Number.isNaN(numeric) ? '' : numeric;
   };
 


### PR DESCRIPTION
## Summary
- correct parseAmount so zero isn't treated as empty

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683bd36a80a88323b5526ceb145a4941