### PR TITLE
Add confirmation options for editing bills

### DIFF
--- a/src/components/PopUpModals/ConfirmApplyModal.jsx
+++ b/src/components/PopUpModals/ConfirmApplyModal.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Modal, Button, Typography } from 'antd';
+import './styles/ConfirmApplyModal.css';
+
+const { Text } = Typography;
+
+const ConfirmApplyModal = ({ open, onJustThis, onAllFuture, onCancel }) => (
+  <Modal
+    open={open}
+    onCancel={onCancel}
+    footer={null}
+    centered
+    width={420}
+    className="confirm-apply-modal"
+  >
+    <div className="confirm-content">
+      <Text className="confirm-question">
+        Do you want to apply the changes to just this bill, or to this bill and all future bills?
+      </Text>
+    </div>
+    <div className="confirm-footer">
+      <Button onClick={onCancel} className="cancel-button">Cancel</Button>
+      <Button onClick={onJustThis} className="single-button">Just This Bill</Button>
+      <Button type="primary" onClick={onAllFuture} className="all-button">All Future Bills</Button>
+    </div>
+  </Modal>
+);
+
+export default ConfirmApplyModal;

--- a/src/components/PopUpModals/styles/ConfirmApplyModal.css
+++ b/src/components/PopUpModals/styles/ConfirmApplyModal.css
@@ -1,0 +1,26 @@
+.confirm-apply-modal .ant-modal-content {
+  border-radius: 20px;
+  overflow: hidden;
+  padding: 0;
+}
+
+.confirm-content {
+  padding: 24px;
+  text-align: center;
+}
+
+.confirm-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 14px 24px;
+  border-top: 1px solid #F0F0F0;
+  gap: 12px;
+}
+
+.confirm-footer .ant-btn {
+  min-width: 100px;
+}
+
+.confirm-apply-modal .confirm-question {
+  font-size: 16px;
+}


### PR DESCRIPTION
## Summary
- create `ConfirmApplyModal` for selecting how to apply bill edits
- style the confirmation modal
- update `EditBillModal` to show confirm prompt on save

## Testing
- `npm test`
- `node tests/due_balanceQuery.test.cjs`
- `npm run build` *(fails: @import must precede all other statements)*

------
https://chatgpt.com/codex/tasks/task_e_683dc1c6302483239f88dd2bcb08ff48