### PR TITLE
Add due date beside category tags

### DIFF
--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
@@ -211,6 +211,18 @@
     white-space: nowrap;
 }
 
+.category-and-date {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.bill-due-date {
+    font-size: 0.75rem;
+    color: var(--neutral-500);
+}
+
 /* Fade animation for bill completion */
 .bill-row-fade-out {
     opacity: 0.5;

--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
@@ -248,32 +248,37 @@ const EnhancedBillRow = ({
                         <div className="bill-name-and-category">
                             <Text strong className="bill-name">{record.name}</Text>
                             {record.category && (
-                                <Tag
-                                    className="bill-category-tag"
-                                    style={{
-                                        margin: 0,
-                                        backgroundColor: 'transparent',
-                                        border: 'none',
-                                        fontSize: '0.75rem',
-                                        padding: '0 4px 0 0'
-                                    }}
-                                >
-                                    <span style={{
-                                        marginRight: '6px',
-                                        display: 'inline-flex',
-                                        alignItems: 'center'
-                                    }}>
-                                        {React.cloneElement(getCategoryIcon(record.category), {
-                                            size: 14,
-                                            style: { color: getCategoryColor(record.category).text }
-                                        })}
+                                <div className="category-and-date">
+                                    <Tag
+                                        className="bill-category-tag"
+                                        style={{
+                                            margin: 0,
+                                            backgroundColor: 'transparent',
+                                            border: 'none',
+                                            fontSize: '0.75rem',
+                                            padding: '0 4px 0 0'
+                                        }}
+                                    >
+                                        <span style={{
+                                            marginRight: '6px',
+                                            display: 'inline-flex',
+                                            alignItems: 'center'
+                                        }}>
+                                            {React.cloneElement(getCategoryIcon(record.category), {
+                                                size: 14,
+                                                style: { color: getCategoryColor(record.category).text }
+                                            })}
+                                        </span>
+                                        <span style={{
+                                            color: getCategoryColor(record.category).text
+                                        }}>
+                                            {record.category}
+                                        </span>
+                                    </Tag>
+                                    <span className="bill-due-date">
+                                        {dayjs(record.dueDate).isValid() ? dayjs(record.dueDate).format('MM/DD/YYYY') : ''}
                                     </span>
-                                    <span style={{
-                                        color: getCategoryColor(record.category).text
-                                    }}>
-                                        {record.category}
-                                    </span>
-                                </Tag>
+                                </div>
                             )}
                         </div>
                         <div className="bill-amount-section">


### PR DESCRIPTION
## Summary
- show due dates next to bill category tags
- style the due date with smaller faded text

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683dccd4de0c8323bd5026e6869c2767