### PR TITLE
Add due date beside Due In

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "react-router-dom": "^7.4.1"
       },
       "devDependencies": {
-        "@eslint/js": "^9.27.0",
+        "@eslint/js": "^9.28.0",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1046,9 +1046,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
-      "integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz",
+      "integrity": "sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-router-dom": "^7.4.1"
   },
   "devDependencies": {
-    "@eslint/js": "^9.27.0",
+    "@eslint/js": "^9.28.0",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",

--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
@@ -211,6 +211,19 @@
     white-space: nowrap;
 }
 
+.due-date-and-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: nowrap;
+}
+
+.bill-due-date {
+    font-size: 0.75rem;
+    color: var(--neutral-500);
+    white-space: nowrap;
+}
+
 /* Fade animation for bill completion */
 .bill-row-fade-out {
     opacity: 0.5;
@@ -265,6 +278,10 @@
         font-size: 11px; /* Specific mobile font size */
         margin-top: 4px;
         padding: 1px var(--space-4); /* Vertical 1px custom, horizontal uses variable */
+    }
+
+    .bill-due-date {
+        font-size: 11px;
     }
 
     .bill-amount-section {

--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
@@ -284,8 +284,13 @@ const EnhancedBillRow = ({
                                         maximumFractionDigits: 2
                                     })}
                                 </Text>
-                                <div className="bill-due-status">
-                                    {renderDueIn(record.dueDate, record)}
+                                <div className="due-date-and-status">
+                                    <span className="bill-due-date">
+                                        {dayjs(record.dueDate).isValid() ? dayjs(record.dueDate).format('MM/DD/YYYY') : ''}
+                                    </span>
+                                    <div className="bill-due-status">
+                                        {renderDueIn(record.dueDate, record)}
+                                    </div>
                                 </div>
                             </div>
                             <Dropdown


### PR DESCRIPTION
## Summary
- move due date display to sit next to the Due In text
- keep gray faded styling and responsive sizing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683dccd4de0c8323bd5026e6869c2767