### PR TITLE
Add Material Symbols icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <meta name="description" content="Financely - Personal finance dashboard application" />
 
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     <title>Financely - Finance Dashboard</title>
 
 

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -102,6 +102,25 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
+.material-symbols-outlined {
+  font-family: 'Material Symbols Outlined';
+  font-variation-settings:
+    'FILL' 0,
+    'wght' 300,
+    'GRAD' -25,
+    'opsz' 40;
+}
+
+@media (max-width: 600px) {
+  .material-symbols-outlined {
+    font-variation-settings:
+      'FILL' 1,
+      'wght' 400,
+      'GRAD' 0,
+      'opsz' 24;
+  }
+}
+
 * {
     box-sizing: border-box;
 }

--- a/src/components/FinanceFeed/MobileFinanceFeed.jsx
+++ b/src/components/FinanceFeed/MobileFinanceFeed.jsx
@@ -5,30 +5,13 @@ import {
   IconAlertOctagon,
   IconClipboardList,
   IconRepeatOff,
-  IconHourglassHigh,
-  IconTimeDuration15,
-  IconChevronDown,
   IconChevronUp,
   IconCircleCheck,
   IconClock,
-  IconCar,
-  IconHome,
-  IconDeviceLaptop,
-  IconWifi,
-  IconDroplet,
-  IconCreditCard,
-  IconShoppingBag,
-  IconHelp, 
-  IconCalendar,
   IconChevronLeft,
-  IconChevronRight,
-  IconCurrencyDollar,
-  IconCertificate, 
-  IconMedicineSyrup, 
-  IconScissors,
-  IconCalendarTime,
-  IconUser
+  IconChevronRight
 } from '@tabler/icons-react';
+import { categoryIcons } from '../../utils/categoryIcons';
 
 import { fetchBills } from '../../services/api';
 import dayjs from 'dayjs';
@@ -36,30 +19,6 @@ import './styles/MobileFinanceFeed.css';
 
 const { Text, Title } = Typography;
 
-// Helper function to get icon based on category
-const getCategoryIcon = (category, size = 16) => {
-  const lowerCategory = category?.toLowerCase() || '';
-
-  if (lowerCategory.includes('car') || lowerCategory.includes('auto')) 
-    return <IconCar size={size} style={{ color: '#FF9233' }} />;
-  if (lowerCategory.includes('home') || lowerCategory.includes('rent')) 
-    return <IconHome size={size} style={{ color: '#F1476F' }} />;
-  if (lowerCategory.includes('internet') || lowerCategory.includes('wifi')) 
-    return <IconWifi size={size} style={{ color: '#0066FF' }} />;
-  if (lowerCategory.includes('water')) 
-    return <IconDroplet size={size} style={{ color: '#26C67B' }} />;
-  if (lowerCategory.includes('gas')) 
-    return <IconDroplet size={size} style={{ color: '#FF9233' }} />;
-  if (lowerCategory.includes('subscription') || lowerCategory.includes('chatgpt')) 
-    return <IconDeviceLaptop size={size} style={{ color: '#0066FF' }} />;
-  if (lowerCategory.includes('medical')) 
-    return <IconClipboardList size={size} style={{ color: '#F1476F' }} />;
-  if (lowerCategory.includes('clothing')) 
-    return <IconShoppingBag size={size} style={{ color: '#0066FF' }} />;
-  if (lowerCategory.includes('passport') || lowerCategory.includes('photos')) 
-    return <IconCreditCard size={size} style={{ color: '#26C67B' }} />;
-  return <IconCreditCard size={size} style={{ color: '#0066FF' }} />;
-};
 
 const MobileFinanceFeed = () => {
 
@@ -311,7 +270,11 @@ const MobileFinanceFeed = () => {
                 shape="circle"
                 className="feed-item-avatar"
                 style={{ backgroundColor: '#FFF5F5', borderRadius: 30 }}
-                icon={getCategoryIcon(item.category, 18)}
+                icon={
+                  <span className="material-symbols-outlined">
+                    {categoryIcons[item.category] || 'category'}
+                  </span>
+                }
               />
               <div className="feed-item-content">
                 <Text className="feed-item-title">{item.name}</Text>
@@ -372,11 +335,15 @@ const MobileFinanceFeed = () => {
           dataSource={limitItems(billPrep, 'billPrep')}
           renderItem={item => (
             <List.Item className="feed-list-item">
-              <Avatar 
-                shape="circle" 
+              <Avatar
+                shape="circle"
                 className="feed-item-avatar"
                 style={{ backgroundColor: '#EBF5FF', borderRadius: 30 }}
-                icon={getCategoryIcon(item.category, 18)}
+                icon={
+                  <span className="material-symbols-outlined">
+                    {categoryIcons[item.category] || 'category'}
+                  </span>
+                }
               />
               <div className="feed-item-content">
                 <Text className="feed-item-title">{item.name}</Text>
@@ -441,7 +408,11 @@ const MobileFinanceFeed = () => {
                 shape="circle"
                 className="feed-item-avatar"
                 style={{ backgroundColor: '#E5F8EF', borderRadius: 30 }}
-                icon={getCategoryIcon(item.category, 18)}
+                icon={
+                  <span className="material-symbols-outlined">
+                    {categoryIcons[item.category] || 'category'}
+                  </span>
+                }
               />
               <div className="feed-item-content">
                 <Text className="feed-item-title">{item.name}</Text>
@@ -512,11 +483,15 @@ const MobileFinanceFeed = () => {
           dataSource={limitItems(upcoming, 'upcoming')}
           renderItem={item => (
             <List.Item className="feed-list-item">
-              <Avatar 
-                shape="circle" 
+              <Avatar
+                shape="circle"
                 className="feed-item-avatar"
                 style={{ backgroundColor: '#EBF5FF', borderRadius: 30 }}
-                icon={getCategoryIcon(item.category, 18)}
+                icon={
+                  <span className="material-symbols-outlined">
+                    {categoryIcons[item.category] || 'category'}
+                  </span>
+                }
               />
               <div className="feed-item-content">
                 <Text className="feed-item-title">{item.name}</Text>

--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
@@ -8,15 +8,12 @@ import {
 } from 'antd';
 import {
     IconCalendarFilled, IconEdit, IconTrash, IconPlus, IconChevronLeft,
-    IconChevronRight, IconHome, IconBolt, IconWifi,
-    IconCreditCard, IconCar, IconShoppingCart, IconHelp,
-    IconCalendar, IconCurrencyDollar, IconCircleCheck, IconClock,
-    IconCertificate, IconMedicineSyrup, IconCalendarTime,
-    IconUser,
+    IconChevronRight,
     IconDotsVertical,
     IconEye,
     IconEyeOff
 } from '@tabler/icons-react';
+import { categoryIcons } from '../../../utils/categoryIcons';
 import { FinanceContext } from '../../../contexts/FinanceContext';
 import EditBillModal from '../../PopUpModals/EditBillModal';
 import MultiBillModal from '../../PopUpModals/MultiBillModal';
@@ -47,9 +44,8 @@ const EnhancedBillRow = ({
     index, 
     onTogglePaid, 
     onEdit, 
-    onDelete, 
-    getCategoryIcon, 
-    getCategoryColor, 
+    onDelete,
+    getCategoryColor,
     renderDueIn, 
     rowClassName,
     isMobile 
@@ -262,12 +258,12 @@ const EnhancedBillRow = ({
                                         <span style={{
                                             marginRight: '6px',
                                             display: 'inline-flex',
-                                            alignItems: 'center'
+                                            alignItems: 'center',
+                                            color: getCategoryColor(record.category).text
                                         }}>
-                                            {React.cloneElement(getCategoryIcon(record.category), {
-                                                size: 14,
-                                                style: { color: getCategoryColor(record.category).text }
-                                            })}
+                                            <span className="material-symbols-outlined">
+                                                {categoryIcons[record.category] || 'category'}
+                                            </span>
                                         </span>
                                         <span style={{
                                             color: getCategoryColor(record.category).text
@@ -506,21 +502,6 @@ const CombinedBillsOverview = ({ style }) => {
     const rowClassName = (record) => (record.id === fadingBillId ? 'bill-row-fade-out' : '');
 
     // Helper functions
-    const getCategoryIcon = (category) => {
-        const lowerCategory = category?.toLowerCase() || '';
-        if (lowerCategory.includes('rent') || lowerCategory.includes('mortgage')) return <IconHome size={16} />;
-        if (lowerCategory.includes('electric') || lowerCategory.includes('utilit')) return <IconBolt size={16} />;
-        if (lowerCategory.includes('card')) return <IconCreditCard size={16} />;
-        if (lowerCategory.includes('auto') || lowerCategory.includes('car')) return <IconCar size={16} />;
-        if (lowerCategory.includes('grocery')) return <IconShoppingCart size={16} />;
-        if (lowerCategory.includes('subscription')) return <IconCalendar size={16} />;
-        if (lowerCategory.includes('loan')) return <IconCurrencyDollar size={16} />;
-        if (lowerCategory.includes('insurance')) return <IconCertificate size={16} />;
-        if (lowerCategory.includes('medical')) return <IconMedicineSyrup size={16} />;
-        if (lowerCategory.includes('personal care')) return <IconUser size={16} />;
-        if (lowerCategory.includes('bill prep')) return <IconCalendarTime size={16} />;
-        return <IconHelp size={16} />;
-    };
 
     const getCategoryColor = (category) => {
         switch (category?.toLowerCase()) {
@@ -669,12 +650,11 @@ const CombinedBillsOverview = ({ style }) => {
                                             fontSize: '0.85rem' 
                                         }}
                                     >
-                                        {React.cloneElement(getCategoryIcon(category), { 
-                                            size: 18,
-                                            style: { 
-                                                color: selectedCategory === category ? getCategoryColor(category).text : 'var(--neutral-700)' 
-                                            }
-                                        })} 
+                                        <span className="material-symbols-outlined" style={{
+                                            color: selectedCategory === category ? getCategoryColor(category).text : 'var(--neutral-700)'
+                                        }}>
+                                            {categoryIcons[category] || 'category'}
+                                        </span>
                                         <span>{category}</span>
                                     </Tag.CheckableTag>
                                 ))}
@@ -697,7 +677,6 @@ const CombinedBillsOverview = ({ style }) => {
                                     onTogglePaid={handleTogglePaid}
                                     onEdit={handleEdit}
                                     onDelete={handleDelete}
-                                    getCategoryIcon={getCategoryIcon}
                                     getCategoryColor={getCategoryColor}
                                     renderDueIn={renderDueIn}
                                     rowClassName={rowClassName}

--- a/src/utils/categoryIcons.js
+++ b/src/utils/categoryIcons.js
@@ -1,0 +1,19 @@
+export const categoryIcons = {
+  Utilities: 'bolt',
+  Rent: 'apartment',
+  Mortgage: 'house_siding',
+  Groceries: 'local_grocery_store',
+  Home: 'home',
+  'Bill Prep': 'receipt_long',
+  Medical: 'medical_services',
+  Insurance: 'verified_user',
+  Loan: 'account_balance',
+  'Credit Card': 'credit_card',
+  Subscription: 'subscriptions',
+  'Personal Care': 'spa',
+  Auto: 'directions_car',
+  Travel: 'flight',
+  Education: 'school',
+  'Family Support': 'group',
+  Other: 'category'
+};


### PR DESCRIPTION
## Summary
- load Material Symbols variable font
- define responsive `.material-symbols-outlined` styles
- map bill categories to Material Symbols
- display category icons using the new font

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683dd5a9a358832395ad05c1975ff766