### PR TITLE
Sync bill category dropdowns

### DIFF
--- a/src/components/PopUpModals/EditBillModal.jsx
+++ b/src/components/PopUpModals/EditBillModal.jsx
@@ -20,30 +20,44 @@ import {
     IconWifi,
     IconDeviceLaptop,
     IconFileText,
-    IconHelp
+    IconHelp,
+    IconPlane,
+    IconSchool,
+    IconUsersGroup
 } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import './styles/EditBillModal.css';
+import { billCategories as categoryNames } from '../../utils/categoryIcons';
 
 const { Option } = Select;
 const { Text } = Typography;
 
-// Enhanced bill categories with icons and colors
-const billCategories = [
-    { name: "Utilities", icon: IconBolt, color: "#FF9500", bgColor: "#FFF2E5" },
-    { name: "Rent", icon: IconHome, color: "#007AFF", bgColor: "#E5F2FF" },
-    { name: "Mortgage", icon: IconHome, color: "#5856D6", bgColor: "#EEEEFD" },
-    { name: "Groceries", icon: IconShoppingCart, color: "#34C759", bgColor: "#E8F8EA" },
-    { name: "Subscription", icon: IconDeviceLaptop, color: "#AF52DE", bgColor: "#F4ECFB" },
-    { name: "Credit Card", icon: IconCreditCard, color: "#FF3B30", bgColor: "#FFE9E8" },
-    { name: "Loan", icon: IconFileText, color: "#FF9500", bgColor: "#FFF2E5" },
-    { name: "Insurance", icon: IconCar, color: "#32D74B", bgColor: "#E8F8EA" },
-    { name: "Medical", icon: IconStethoscope, color: "#FF3B30", bgColor: "#FFE9E8" },
-    { name: "Personal Care", icon: IconHelp, color: "#5856D6", bgColor: "#EEEEFD" },
-    { name: "Bill Prep", icon: IconCalendar, color: "#007AFF", bgColor: "#E5F2FF" },
-    { name: "Auto", icon: IconCar, color: "#FF9500", bgColor: "#FFF2E5" },
-    { name: "Other", icon: IconHelp, color: "#8E8E93", bgColor: "#F2F2F7" }
-];
+// Category metadata with icons and colors
+const categoryDetails = {
+    Utilities: { icon: IconBolt, color: "#FF9500", bgColor: "#FFF2E5" },
+    Rent: { icon: IconHome, color: "#007AFF", bgColor: "#E5F2FF" },
+    Mortgage: { icon: IconHome, color: "#5856D6", bgColor: "#EEEEFD" },
+    Groceries: { icon: IconShoppingCart, color: "#34C759", bgColor: "#E8F8EA" },
+    Subscription: { icon: IconDeviceLaptop, color: "#AF52DE", bgColor: "#F4ECFB" },
+    "Credit Card": { icon: IconCreditCard, color: "#FF3B30", bgColor: "#FFE9E8" },
+    Loan: { icon: IconFileText, color: "#FF9500", bgColor: "#FFF2E5" },
+    Insurance: { icon: IconCar, color: "#32D74B", bgColor: "#E8F8EA" },
+    Medical: { icon: IconStethoscope, color: "#FF3B30", bgColor: "#FFE9E8" },
+    "Personal Care": { icon: IconHelp, color: "#5856D6", bgColor: "#EEEEFD" },
+    "Bill Prep": { icon: IconCalendar, color: "#007AFF", bgColor: "#E5F2FF" },
+    Auto: { icon: IconCar, color: "#FF9500", bgColor: "#FFF2E5" },
+    Travel: { icon: IconPlane, color: "#FF9500", bgColor: "#FFF2E5" },
+    Education: { icon: IconSchool, color: "#AF52DE", bgColor: "#F4ECFB" },
+    "Family Support": { icon: IconUsersGroup, color: "#5856D6", bgColor: "#EEEEFD" },
+    Home: { icon: IconHome, color: "#007AFF", bgColor: "#E5F2FF" },
+    Other: { icon: IconHelp, color: "#8E8E93", bgColor: "#F2F2F7" }
+};
+
+// Build final list of bill categories using global names
+const billCategories = categoryNames.map(name => ({
+    name,
+    ...(categoryDetails[name] || { icon: IconHelp, color: '#8E8E93', bgColor: '#F2F2F7' })
+}));
 
 const UnifiedEditBillModal = ({ open, onCancel, onSubmit, bill }) => {
   const [form] = Form.useForm();

--- a/src/components/PopUpModals/MultiBillModal.jsx
+++ b/src/components/PopUpModals/MultiBillModal.jsx
@@ -13,16 +13,12 @@ import {
 import dayjs from 'dayjs';
 import { FinanceContext } from '../../contexts/FinanceContext';
 import './styles/MultiBillModal.css';
+import { billCategories } from '../../utils/categoryIcons';
 
 const { Title, Text } = Typography;
 const { Option } = Select;
 
-// Define categories here or get them from context if available globally
-const billCategories = [
-  "Utilities", "Rent", "Mortgage", "Groceries", "Subscription",
-  "Credit Card", "Loan", "Insurance", "Medical", "Personal Care",
-  "Bill Prep", "Auto", "Other"
-];
+// Bill categories sourced from global configuration
 
 export default function MultiBillModal({ open, onClose, onBillsAdded }) {
   const [form] = Form.useForm();

--- a/src/utils/categoryIcons.js
+++ b/src/utils/categoryIcons.js
@@ -17,3 +17,5 @@ export const categoryIcons = {
   'Family Support': 'group',
   Other: 'category'
 };
+
+export const billCategories = Object.keys(categoryIcons);


### PR DESCRIPTION
## Summary
- export `billCategories` from the shared `categoryIcons` utility
- pull categories from that config in MultiBillModal (Add Bills)
- build EditBillModal category options based on the same list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683def7d53e4832396f0503bd3610863