### PR TITLE
Integrate Finance Feed into dashboard layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -114,12 +114,17 @@ function MyApp() {
       case 'dashboard':
         return (
           <Row gutter={isMobileView ? [8, 16] : [24, 24]}>
-            <Col xs={24} lg={24}>
+            <Col xs={24}>
               <FinancialOverviewCards />
-              <div style={{
-                marginBottom: (isMobileView && isBillsListExpanded) ? '60px' : '0px',
-                transition: 'margin-bottom 0.2s ease-in-out'
-              }}>
+            </Col>
+
+            <Col xs={24} lg={16}>
+              <div
+                style={{
+                  marginBottom: isMobileView && isBillsListExpanded ? '60px' : '0px',
+                  transition: 'margin-bottom 0.2s ease-in-out',
+                }}
+              >
                 <div style={{ marginTop: isMobileView ? 0 : 24 }}>
                   <CombinedBillsOverview
                     style={{ height: '100%' }}
@@ -132,16 +137,16 @@ function MyApp() {
             </Col>
 
             {!isMobileView && (
-              <Col xs={24} lg={7} style={{ width: '100%' }}>
+              <Col xs={24} lg={8} style={{ width: '100%' }}>
                 <div
                   style={{
                     display: 'flex',
                     flexDirection: 'column',
                     gap: 24,
-                    width: '100%'
+                    width: '100%',
                   }}
                 >
-                  {}
+                  <FinanceFeed onEditBill={handleOpenEditBillModal} onAddBill={handleOpenAddBillModal} />
                 </div>
               </Col>
             )}

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -1,6 +1,6 @@
 // src/components/Sidebar/Sidebar.jsx
 import React, { useContext, useState, useMemo } from 'react';
-import { Layout, Menu, Spin, Button, Tooltip, Space, message, Typography, Dropdown } from 'antd';
+import { Layout, Menu, Spin, Button, Tooltip, Space, message, Typography, Dropdown, Grid } from 'antd';
 import {
   IconHomeFilled,
   IconChartPieFilled,
@@ -42,6 +42,7 @@ import './Sidebar.css';
 
 const { Sider } = Layout;
 const { Text } = Typography;
+const { useBreakpoint } = Grid;
 
 // Sortable card item for drag-and-drop
 const SortableCardItem = ({ id, card, collapsed, onEdit, onDelete, isOverlay = false }) => {
@@ -148,6 +149,9 @@ const Sidebar = ({
   // State to track the ID of the item being dragged
   const [activeId, setActiveId] = useState(null);
 
+  const screens = useBreakpoint();
+  const isDesktop = screens.md;
+
   // Modal control functions
   const showAddModal = () => setIsAddModalVisible(true);
   const handleAddModalClose = () => setIsAddModalVisible(false);
@@ -206,9 +210,11 @@ const Sidebar = ({
   // Define the main navigation menu items
   const mainMenuItems = [
     { label: 'Dashboard', key: 'dashboard', icon: <IconHomeFilled size={20} /> },
-    { label: 'Finance Feed', key: 'finance-feed', icon: <IconActivityHeartbeat size={20} /> },
-    { label: 'Reports',   key: 'reports',   icon: <IconChartPieFilled size={20} /> },
-    { label: 'Settings',  key: 'settings',  icon: <IconSettings size={20} /> },
+    ...(!isDesktop
+      ? [{ label: 'Finance Feed', key: 'finance-feed', icon: <IconActivityHeartbeat size={20} /> }]
+      : []),
+    { label: 'Reports', key: 'reports', icon: <IconChartPieFilled size={20} /> },
+    { label: 'Settings', key: 'settings', icon: <IconSettings size={20} /> },
   ];
 
   // Memoize credit card IDs for dnd-kit context


### PR DESCRIPTION
## Summary
- display Finance Feed beside bills overview on desktop dashboard
- hide Finance Feed menu item in desktop sidebar

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683df40a059c8323afa8d5baf688d123