### PR TITLE
Fix missing icon import and service worker cache

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -2,20 +2,23 @@ const CACHE_NAME = 'financely-v1';
 const urlsToCache = [
   '/',
   '/index.html',
-  '/src/main.jsx',
-  '/src/assets/styles/global.css',
+  '/vite.svg',
   // Add other important assets here
 ];
 
 // Install a service worker
 self.addEventListener('install', event => {
-  event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then(cache => {
-        console.log('Opened cache');
-        return cache.addAll(urlsToCache);
-      })
-  );
+  event.waitUntil((async () => {
+    const cache = await caches.open(CACHE_NAME);
+    console.log('Opened cache');
+    for (const url of urlsToCache) {
+      try {
+        await cache.add(url);
+      } catch (e) {
+        console.error('Failed to cache', url, e);
+      }
+    }
+  })());
 });
 
 // Cache and return requests

--- a/src/components/FinanceFeed/MobileFinanceFeed.jsx
+++ b/src/components/FinanceFeed/MobileFinanceFeed.jsx
@@ -8,6 +8,8 @@ import {
   IconChevronUp,
   IconCircleCheck,
   IconClock,
+  IconHourglassHigh,
+  IconTimeDuration15,
   IconChevronLeft,
   IconChevronRight
 } from '@tabler/icons-react';


### PR DESCRIPTION
## Summary
- import the missing hourglass icon for MobileFinanceFeed
- switch service worker install to individual cache.add calls
- remove bad URLs from service worker cache list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683df875eed8832388b4d4f25a5be18d