### PR TITLE
Update feed month selector & desktop dashboard layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -112,44 +112,57 @@ function MyApp() {
   const renderContent = () => {
     switch (selectedMenuKey) {
       case 'dashboard':
-        return (
-          <Row gutter={isMobileView ? [8, 16] : [24, 24]}>
-            <Col xs={24}>
-              <FinancialOverviewCards />
-            </Col>
-
-            <Col xs={24} lg={16}>
-              <div
-                style={{
-                  marginBottom: isMobileView && isBillsListExpanded ? '60px' : '0px',
-                  transition: 'margin-bottom 0.2s ease-in-out',
-                }}
-              >
-                <div style={{ marginTop: isMobileView ? 0 : 24 }}>
-                  <CombinedBillsOverview
-                    style={{ height: '100%' }}
-                    onEditBill={handleOpenEditBillModal}
-                    onAddBill={handleOpenAddBillModal}
-                    onExpansionChange={handleBillsExpansionChange}
-                  />
-                </div>
-              </div>
-            </Col>
-
-            {!isMobileView && (
-              <Col xs={24} lg={8} style={{ width: '100%' }}>
+        if (isMobileView) {
+          return (
+            <Row gutter={[8, 16]}>
+              <Col xs={24}>
+                <FinancialOverviewCards />
+              </Col>
+              <Col xs={24}>
                 <div
                   style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 24,
-                    width: '100%',
+                    marginBottom: isBillsListExpanded ? '60px' : '0px',
+                    transition: 'margin-bottom 0.2s ease-in-out',
                   }}
                 >
-                  <FinanceFeed onEditBill={handleOpenEditBillModal} onAddBill={handleOpenAddBillModal} />
+                  <div style={{ marginTop: 0 }}>
+                    <CombinedBillsOverview
+                      style={{ height: '100%' }}
+                      onEditBill={handleOpenEditBillModal}
+                      onAddBill={handleOpenAddBillModal}
+                      onExpansionChange={handleBillsExpansionChange}
+                    />
+                  </div>
                 </div>
               </Col>
-            )}
+            </Row>
+          );
+        }
+        return (
+          <Row gutter={[24, 24]}>
+            <Col xs={24} lg={6}>
+              <FinancialOverviewCards />
+            </Col>
+            <Col xs={24} lg={10}>
+              <CombinedBillsOverview
+                style={{ height: '100%', marginTop: 24 }}
+                onEditBill={handleOpenEditBillModal}
+                onAddBill={handleOpenAddBillModal}
+                onExpansionChange={handleBillsExpansionChange}
+              />
+            </Col>
+            <Col xs={24} lg={8} style={{ width: '100%' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 24,
+                  width: '100%',
+                }}
+              >
+                <FinanceFeed onEditBill={handleOpenEditBillModal} onAddBill={handleOpenAddBillModal} />
+              </div>
+            </Col>
           </Row>
         );
 

--- a/src/components/FinanceFeed/MobileFinanceFeed.jsx
+++ b/src/components/FinanceFeed/MobileFinanceFeed.jsx
@@ -9,9 +9,7 @@ import {
   IconCircleCheck,
   IconClock,
   IconHourglassHigh,
-  IconTimeDuration15,
-  IconChevronLeft,
-  IconChevronRight
+  IconTimeDuration15
 } from '@tabler/icons-react';
 import { categoryIcons } from '../../utils/categoryIcons';
 
@@ -229,23 +227,20 @@ const MobileFinanceFeed = () => {
   return (
     <Spin spinning={loading}>
     <div className="finance-feed-mobile">
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: 8 }}>
-        <Button
-          type="text"
-          icon={<IconChevronLeft size={16} />}
-          onClick={() => setFeedMonth(prev => prev.subtract(1, 'month'))}
-        />
-        <span style={{ flexGrow: 1, textAlign: 'center', fontWeight: 600 }}>
-          {feedMonth.format('MMMM')}
-        </span>
-        <Button
-          type="text"
-          icon={<IconChevronRight size={16} />}
-          onClick={() => setFeedMonth(prev => prev.add(1, 'month'))}
-        />
+      <Title level={4} style={{ marginBottom: 8 }}>Finance Feed</Title>
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: 16 }}>
+        <Select
+          value={feedMonth.month()}
+          style={{ width: 120, marginRight: 8 }}
+          onChange={month => setFeedMonth(prev => prev.month(month))}
+        >
+          {dayjs.months().map((m, idx) => (
+            <Select.Option key={idx} value={idx}>{m}</Select.Option>
+          ))}
+        </Select>
         <Select
           value={feedMonth.year()}
-          style={{ width: 80, marginLeft: 8 }}
+          style={{ width: 80 }}
           onChange={year => setFeedMonth(prev => prev.year(year))}
         >
           {Array.from({ length: 5 }, (_, i) => dayjs().year() - 2 + i).map(y => (
@@ -253,7 +248,6 @@ const MobileFinanceFeed = () => {
           ))}
         </Select>
       </div>
-      <Title level={4} style={{ marginBottom: 16 }}>Finance Feed</Title>
 
       {/* Past Due Payments */}
       <SectionCard


### PR DESCRIPTION
## Summary
- replace FinanceFeed arrow month navigation with month dropdown
- tweak dashboard layout on desktop so summary cards, bills overview, and feed sit side‑by‑side

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683dfc8f627483238b4acaf5f09a7026