### PR TITLE
Fix service worker and load Day.js plugins

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -23,6 +23,11 @@ self.addEventListener('install', event => {
 
 // Cache and return requests
 self.addEventListener('fetch', event => {
+  // Ignore non-HTTP requests such as chrome-extension:// URLs
+  if (!event.request.url.startsWith('http')) {
+    return;
+  }
+
   event.respondWith(
     caches.match(event.request)
       .then(response => {

--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
@@ -10,7 +10,12 @@ import MultiBillModal from '../../PopUpModals/MultiBillModal';
 import DeleteBillModal from '../../PopUpModals/DeleteBillModal';
 import MonthlyProgressSummary from './MonthlyProgressSummary';
 import dayjs from 'dayjs';
+import isBetween from 'dayjs/plugin/isBetween';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import './CombinedBillsOverview.css';
+
+dayjs.extend(isBetween);
+dayjs.extend(isSameOrAfter);
 
 const { Text } = Typography;
 const { useBreakpoint } = Grid;
@@ -331,6 +336,7 @@ const CombinedBillsOverview = ({ style }) => {
     loading,
     error,
     updateBill,
+    updateBillWithFuture,
     deleteBill,
     deleteMasterBill,
     addBill,


### PR DESCRIPTION
## Summary
- skip caching non-http URLs in service worker
- load `isBetween` and `isSameOrAfter` plugins for Day.js
- pull `updateBillWithFuture` from context

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683e1af631cc8323acb2ab13825015b8