### PR TITLE
UI spacing tweaks and category color update

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -507,7 +507,7 @@ textarea {
   }
 
   .financial-overview-row .ant-card-body {
-    padding: 8px 8px !important;
+    padding: 6px 8px !important;
     height: 75px !important;
     display: flex !important;
     flex-direction: column !important;

--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
@@ -501,6 +501,8 @@ const CombinedBillsOverview = ({ style }) => {
         return { text: '#6B9FD4', bg: '#F5F8FC' };
       case 'auto':
         return { text: '#D4B56B', bg: '#FCFAF5' };
+      case 'family support':
+        return { text: '#69C9AF', bg: '#E7FBF5' };
       default:
         return { text: '#9B9B9B', bg: '#F8F8F8' };
     }
@@ -680,7 +682,7 @@ const CombinedBillsOverview = ({ style }) => {
                       backgroundColor:
                         selectedCategory === category
                           ? getCategoryColor(category).bg
-                          : 'var(--neutral-50)',
+                          : 'var(--neutral-100)',
                       color:
                         selectedCategory === category
                           ? getCategoryColor(category).text

--- a/src/components/FinancialSummary/CombinedBillsOverview/MonthlyProgressSummary.css
+++ b/src/components/FinancialSummary/CombinedBillsOverview/MonthlyProgressSummary.css
@@ -31,6 +31,9 @@
         display: flex;
         align-items: center;
         justify-content: center;
+        width: 32px;
+        height: 32px;
+        border-radius: var(--border-radius-md);
     }
 
     .month-display {
@@ -108,6 +111,9 @@
     
     .nav-button {
         margin: 0 var(--space-8); /* Was 0 8px */
+        width: 28px;
+        height: 28px;
+        border-radius: var(--border-radius-md);
     }
     
     .progress-badge {

--- a/src/components/FinancialSummary/CombinedBillsOverview/MonthlyProgressSummary.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/MonthlyProgressSummary.jsx
@@ -76,7 +76,7 @@ const MonthlyProgressSummary = ({
                 {/* Month Navigation */}
                 <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', marginBottom: 'var(--space-20)' }}>
                     <Tooltip title="Previous Month">
-                        <Button shape="circle" icon={<IconChevronLeft size={16} />} onClick={goToPreviousMonth} style={{ margin: '0 var(--space-16)' }} />
+                        <Button icon={<IconChevronLeft size={16} />} onClick={goToPreviousMonth} style={{ margin: '0 var(--space-16)' }} />
                     </Tooltip>
                     <div style={{ textAlign: 'center', minWidth: '100px' }}>
                         <Paragraph style={{ margin: 0, fontWeight: 600, fontSize: '1.25rem', lineHeight: 1.2, color: 'var(--neutral-800)', marginBottom: '2px' }}>
@@ -87,7 +87,7 @@ const MonthlyProgressSummary = ({
                         </Paragraph>
                     </div>
                     <Tooltip title="Next Month">
-                        <Button shape="circle" icon={<IconChevronRight size={16} />} onClick={goToNextMonth} style={{ margin: '0 var(--space-16)' }} />
+                        <Button icon={<IconChevronRight size={16} />} onClick={goToNextMonth} style={{ margin: '0 var(--space-16)' }} />
                     </Tooltip>
                 </div>
             </div>
@@ -98,7 +98,6 @@ const MonthlyProgressSummary = ({
                 <div className="month-navigation">
                     <Tooltip title="Previous Month">
                         <Button 
-                            shape="circle" 
                             icon={<IconChevronLeft size={16} />} 
                             onClick={goToPreviousMonth} 
                             className="nav-button"
@@ -110,7 +109,6 @@ const MonthlyProgressSummary = ({
                     </div>
                     <Tooltip title="Next Month">
                         <Button 
-                            shape="circle" 
                             icon={<IconChevronRight size={16} />} 
                             onClick={goToNextMonth} 
                             className="nav-button"

--- a/src/components/PopUpModals/EditBillModal.jsx
+++ b/src/components/PopUpModals/EditBillModal.jsx
@@ -48,7 +48,7 @@ const categoryDetails = {
     Auto: { icon: IconCar, color: "#FF9500", bgColor: "#FFF2E5" },
     Travel: { icon: IconPlane, color: "#FF9500", bgColor: "#FFF2E5" },
     Education: { icon: IconSchool, color: "#AF52DE", bgColor: "#F4ECFB" },
-    "Family Support": { icon: IconUsersGroup, color: "#5856D6", bgColor: "#EEEEFD" },
+    "Family Support": { icon: IconUsersGroup, color: "#69C9AF", bgColor: "#E7FBF5" },
     Home: { icon: IconHome, color: "#007AFF", bgColor: "#E5F2FF" },
     Other: { icon: IconHelp, color: "#8E8E93", bgColor: "#F2F2F7" }
 };


### PR DESCRIPTION
## Summary
- lighten category tag default background
- square mobile month navigation buttons and update CSS
- add unique color for Family Support category
- tighten padding of overview cards on mobile

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683e2f3629d08323affa14464f640d6e