### PR TITLE
Refine mobile layout and category tag styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -115,7 +115,7 @@ function MyApp() {
       case 'dashboard':
         if (isMobileView) {
           return (
-            <Row gutter={[8, 16]}>
+            <Row gutter={[8, 8]}>
               <Col xs={24}>
                 <FinancialOverviewCards />
               </Col>

--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.css
@@ -345,3 +345,20 @@
     outline: 2px solid rgba(255, 255, 255, 0.8); /* White outline for visibility on dark action buttons */
     outline-offset: -2px;
 }
+
+/* Spacing adjustments for card container */
+.combined-bills-card {
+    margin-top: var(--space-24);
+}
+
+@media (max-width: 767px) {
+    .combined-bills-card {
+        margin-top: var(--space-8);
+    }
+}
+
+@media (min-width: 768px) and (max-width: 991px) {
+    .combined-bills-card {
+        margin-top: var(--space-24);
+    }
+}

--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
@@ -502,7 +502,7 @@ const CombinedBillsOverview = ({ style }) => {
       case 'auto':
         return { text: '#D4B56B', bg: '#FCFAF5' };
       case 'family support':
-        return { text: '#69C9AF', bg: '#E7FBF5' };
+        return { text: '#69C9AF', bg: '#F1F5F9' };
       default:
         return { text: '#9B9B9B', bg: '#F8F8F8' };
     }
@@ -574,7 +574,11 @@ const CombinedBillsOverview = ({ style }) => {
 
   return (
     <>
-      <Card style={{ ...style, borderRadius: '20px', boxShadow: 'none' }} bodyStyle={{ padding: 0 }}>
+      <Card
+        className="combined-bills-card"
+        style={{ ...style, borderRadius: '20px', boxShadow: 'none' }}
+        bodyStyle={{ padding: 0 }}
+      >
         <Spin spinning={loading} tip="Loading Bills...">
           {/* Header → Monthly Progress + Month Nav */}
           <div style={{ padding: 'var(--space-20)', paddingBottom: 'calc(var(--space-20) * 0.1)' }}>
@@ -686,7 +690,7 @@ const CombinedBillsOverview = ({ style }) => {
                       color:
                         selectedCategory === category
                           ? getCategoryColor(category).text
-                          : 'var(--neutral-700)',
+                          : '#9e9e9e',
                       lineHeight: '1.4',
                       fontSize: '0.85rem',
                     }}
@@ -695,10 +699,10 @@ const CombinedBillsOverview = ({ style }) => {
                       className="material-symbols-outlined"
                       style={{
                         color: isSmallScreen
-                          ? 'var(--neutral-600)'
+                          ? '#9e9e9e'
                           : selectedCategory === category
                           ? getCategoryColor(category).text
-                          : 'var(--neutral-700)',
+                          : '#9e9e9e',
                         fontSize: isSmallScreen ? '14px' : undefined,
                       }}
                     >

--- a/src/components/FinancialSummary/CombinedBillsOverview/MonthlyProgressSummary.css
+++ b/src/components/FinancialSummary/CombinedBillsOverview/MonthlyProgressSummary.css
@@ -31,9 +31,9 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        width: 32px;
-        height: 32px;
-        border-radius: var(--border-radius-md);
+        width: 36px;
+        height: 36px;
+        border-radius: 6px;
     }
 
     .month-display {
@@ -111,9 +111,9 @@
     
     .nav-button {
         margin: 0 var(--space-8); /* Was 0 8px */
-        width: 28px;
-        height: 28px;
-        border-radius: var(--border-radius-md);
+        width: 32px;
+        height: 32px;
+        border-radius: 6px;
     }
     
     .progress-badge {


### PR DESCRIPTION
## Summary
- reduce dashboard spacing for mobile
- tweak category tag colors and family support tag
- enlarge month nav buttons
- add responsive margin for monthly bills card

## Testing
- `npm test`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683e499226bc8323aabe6d9df19bea5d