### PR TITLE
Fix category carousel colors and tablet layout

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -379,7 +379,7 @@ textarea {
     display: block;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 991px) {
   .hide-on-mobile {
     display: none !important;
   }
@@ -427,7 +427,7 @@ textarea {
 
   .category-tags-container .material-symbols-outlined {
     font-size: 14px !important;
-    color: var(--neutral-600) !important;
+    color: inherit !important;
   }
 
   .all-categories-btn {

--- a/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
+++ b/src/components/FinancialSummary/CombinedBillsOverview/CombinedBillsOverview.jsx
@@ -503,6 +503,8 @@ const CombinedBillsOverview = ({ style }) => {
         return { text: '#D4B56B', bg: '#FCFAF5' };
       case 'family support':
         return { text: '#69C9AF', bg: '#F1F5F9' };
+      case 'home':
+        return { text: '#6BA4D4', bg: '#F0F6FC' };
       default:
         return { text: '#9B9B9B', bg: '#F8F8F8' };
     }
@@ -698,11 +700,10 @@ const CombinedBillsOverview = ({ style }) => {
                     <span
                       className="material-symbols-outlined"
                       style={{
-                        color: isSmallScreen
-                          ? '#9e9e9e'
-                          : selectedCategory === category
-                          ? getCategoryColor(category).text
-                          : '#9e9e9e',
+                        color:
+                          selectedCategory === category
+                            ? getCategoryColor(category).text
+                            : '#9e9e9e',
                         fontSize: isSmallScreen ? '14px' : undefined,
                       }}
                     >


### PR DESCRIPTION
## Summary
- ensure category icons follow tag color
- add Home color mapping
- allow category carousel to scroll on tablets

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683e514b522883239111ce382e9730f3