### PR TITLE
Improve month nav button size

### DIFF
--- a/src/components/FinancialSummary/CombinedBillsOverview/MonthlyProgressSummary.css
+++ b/src/components/FinancialSummary/CombinedBillsOverview/MonthlyProgressSummary.css
@@ -31,9 +31,9 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        width: 36px;
-        height: 36px;
-        border-radius: 6px;
+        width: 44px;
+        height: 44px;
+        border-radius: 18px;
     }
 
     .month-display {
@@ -111,9 +111,9 @@
     
     .nav-button {
         margin: 0 var(--space-8); /* Was 0 8px */
-        width: 32px;
-        height: 32px;
-        border-radius: 6px;
+        width: 40px;
+        height: 40px;
+        border-radius: 18px;
     }
     
     .progress-badge {


### PR DESCRIPTION
## Summary
- enlarge the previous/next month buttons for better touch targets
- add 18px border-radius to mobile and tablet nav buttons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683f25ea31a48323900dc49747aed238