### PR TITLE
Fix amount validation in Edit Bill form

### DIFF
--- a/src/components/PopUpModals/EditBillModal.jsx
+++ b/src/components/PopUpModals/EditBillModal.jsx
@@ -272,7 +272,13 @@ const UnifiedEditBillModal = ({ open, onCancel, onSubmit, bill }) => {
                     name="amount"
                     rules={[
                       { required: true, message: 'Required' },
-                      { type: 'number', min: 0.01, message: 'Must be positive' }
+                      {
+                        validator: (_, value) => {
+                          const numeric = Number(value);
+                          if (numeric > 0) return Promise.resolve();
+                          return Promise.reject(new Error('Must be positive'));
+                        }
+                      }
                     ]}
                     className="amount-input"
                   >


### PR DESCRIPTION
## Summary
- patch validation rules for `EditBillModal` so positive amounts are accepted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841b606a0c48323882801516c32c264