### PR TITLE
Fix editing recurring bills

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -82,6 +82,27 @@ export const updateBill = async (id, updatedData) => {
     }
 };
 
+export const updateFutureBills = async (masterId, fromDate, updatedData) => {
+    try {
+        let url = `${API_URL}/master-bills/${masterId}`;
+        if (fromDate) {
+            url += `?from=${encodeURIComponent(fromDate)}`;
+        }
+        const response = await fetch(url, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(updatedData),
+        });
+        if (!response.ok) {
+            throw await handleApiError(response);
+        }
+        return await response.json();
+    } catch (error) {
+        console.error(`Error in updateFutureBills for master ID ${masterId}:`, error);
+        throw error;
+    }
+};
+
 export const deleteBill = async (id) => {
     try {
         const response = await fetch(`${API_URL}/bills/${id}?mode=instance`, { method: 'DELETE' });


### PR DESCRIPTION
## Summary
- support applying edits to future recurring bills on the server
- add API client for updating future bills
- use new API from FinanceContext to apply updates when "All Future" is chosen

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852c189ebf883239aaacc93bd007c66